### PR TITLE
Atomically update next_auto_assign_ip

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -476,9 +476,41 @@ def subnet_find_ordered_by_most_full(context, net_id, **filters):
         query = query.filter(models.Subnet.ip_version == filters["ip_version"])
     if "segment_id" in filters and filters["segment_id"]:
         query = query.filter(models.Subnet.segment_id == filters["segment_id"])
+    query = query.filter(models.Subnet.next_auto_assign_ip != -1)
+
     if "subnet_id" in filters and filters["subnet_id"]:
         query = query.filter(models.Subnet.id.in_(filters["subnet_id"]))
+    return query
+
+
+def subnet_update_next_auto_assign_ip(context, subnet):
+    query = context.session.query(models.Subnet)
+    query = query.filter(models.Subnet.id == subnet["id"])
     query = query.filter(models.Subnet.next_auto_assign_ip != -1)
+
+    # For details on synchronize_session, see:
+    # http://docs.sqlalchemy.org/en/rel_0_8/orm/query.html
+    query = query.update(
+        {"next_auto_assign_ip":
+         models.Subnet.next_auto_assign_ip + 1},
+        synchronize_session=False)
+
+    # Returns a count of the rows matched in the update
+    return query
+
+
+def subnet_update_set_full(context, subnet):
+    query = context.session.query(models.Subnet)
+    query = query.filter_by(id=subnet["id"])
+    query = query.filter(models.Subnet.next_auto_assign_ip != -1)
+
+    # For details on synchronize_session, see:
+    # http://docs.sqlalchemy.org/en/rel_0_8/orm/query.html
+    query = query.update(
+        {"next_auto_assign_ip": -1},
+        synchronize_session=False)
+
+    # Returns a count of the rows matched in the update
     return query
 
 

--- a/quark/db/custom_types.py
+++ b/quark/db/custom_types.py
@@ -34,6 +34,16 @@ class INET(types.TypeDecorator):
             return value
         return long(value)
 
+    def coerce_compared_value(self, op, value):
+        # NOTE(mdietz): If left unimplemented, the column is coerced into a
+        # string every time, causing the next_auto_assign_increment to be a
+        # string concatenation rather than an addition. 'value' in the
+        # signature is the "other" value being compared for the purposes of
+        # casting.
+        if isinstance(value, int):
+            return types.Integer()
+        return self
+
 
 class MACAddress(types.TypeDecorator):
     impl = types.BigInteger

--- a/quark/tests/functional/db/test_api.py
+++ b/quark/tests/functional/db/test_api.py
@@ -155,3 +155,34 @@ class QuarkFindSubnetAllocationCount(QuarkIpamBaseFunctionalTest):
                 scope=db_api.ALL).all()
             self.assertEqual(subnets[0][0].ip_version, 4)
             self.assertEqual(subnets[1][0].ip_version, 6)
+
+    def test_subnet_set_full(self):
+        cidr4 = "0.0.0.0/30"  # 2 bits
+        net4 = netaddr.IPNetwork(cidr4)
+        with self._fixtures([
+            self._create_models(cidr4, 4, net4[0])
+        ]) as net:
+            subnet = db_api.subnet_find(self.context, network_id=net['id'],
+                                        scope=db_api.ALL)[0]
+            with self.context.session.begin():
+                updated = db_api.subnet_update_set_full(self.context, subnet)
+                self.context.session.refresh(subnet)
+                self.assertTrue(updated)
+                self.assertEqual(subnet["next_auto_assign_ip"], -1)
+
+    def test_subnet_update_next_auto_assign_ip(self):
+        cidr4 = "0.0.0.0/30"  # 2 bits
+        net4 = netaddr.IPNetwork(cidr4)
+        with self._fixtures([
+            self._create_models(cidr4, 4, net4[0])
+        ]) as net:
+            subnet = db_api.subnet_find(self.context, network_id=net['id'],
+                                        scope=db_api.ALL)[0]
+            with self.context.session.begin():
+                updated = db_api.subnet_update_next_auto_assign_ip(
+                    self.context, subnet)
+                self.context.session.refresh(subnet)
+                self.assertTrue(updated)
+                self.assertEqual(
+                    netaddr.IPAddress(subnet["next_auto_assign_ip"]).ipv4(),
+                    net4[1])


### PR DESCRIPTION
RM10879

Modifies quark IPAM to atomically update the next_auto_assign_ip field
on subnets without using row locks. The previous implementation was
racy, allowing for the code to set explicit values rather than
incrementing the column as if it were a counter entirely in SQL.