### PR TITLE
Delete MAC addresses in ranges marked do_not_use

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -325,6 +325,10 @@ def mac_address_find(context, lock_mode=False, **filters):
     return query.filter(*model_filters)
 
 
+def mac_address_delete(context, mac_address):
+    context.session.delete(mac_address)
+
+
 def mac_address_range_find_allocation_counts(context, address=None):
     count = sql_func.count(models.MacAddress.address)
     query = context.session.query(models.MacAddressRange,
@@ -336,6 +340,7 @@ def mac_address_range_find_allocation_counts(context, address=None):
         query = query.filter(models.MacAddressRange.last_address >= address)
         query = query.filter(models.MacAddressRange.first_address <= address)
     query = query.filter(models.MacAddressRange.next_auto_assign_mac != -1)
+    query = query.filter(models.MacAddressRange.do_not_use == False)  # noqa
     query = query.limit(1)
     return query.first()
 


### PR DESCRIPTION
RM11043

Implements use of the do_not_use column on mac_address_ranges.
Additionally, sets a rule in place that if a MAC is deallocated in a
range marked as do_not_use, it's deleted instead of deallocated. The
reason for this is two fold:

* We needed a fast fix to unblock other work being done with Neutron
* Introducing the logic necessary to handle deallocating and not reusing
  MACs in the current implementation would also introduce a new chance
  for deadlocks as MAC address ranges would have to be included in all
  queries for MAC address reallocation.
* I have an in-progress fix for removing the SELECT FOR UPDATE when
  reallocating MAC addresses, but there are flaws I have yet to work
  around. Rather than rush the fix, I decided to create a less than
  optimal path so we could move the ball forward.