### PR TITLE
Updates for security groups Redis schema

### DIFF
--- a/quark/security_groups/redis_client.py
+++ b/quark/security_groups/redis_client.py
@@ -170,7 +170,7 @@ class Client(object):
 
         The rule schema is the following:
 
-        REDIS KEY - port_device_id.port_mac_address
+        REDIS KEY - port_device_id.port_mac_address/sg
         REDIS VALUE - A JSON dump of the following:
 
         port_mac_address must be lower-cased and stripped of non-alphanumeric
@@ -213,7 +213,7 @@ class Client(object):
 
         # Lower cases and strips hyphens from the mac
         mac = mac.translate(MAC_TRANS_TABLE, ":-")
-        return "{0}.{1}".format(device_id, mac)
+        return "{0}.{1}/sg".format(device_id, mac)
 
     def get_rules_for_port(self, device_id, mac_address):
         rules = self._client.get(

--- a/quark/tests/security_groups/test_redis_client.py
+++ b/quark/tests/security_groups/test_redis_client.py
@@ -47,7 +47,7 @@ class TestRedisSerialization(test_base.TestBase):
         mac_address = netaddr.EUI("AA:BB:CC:DD:EE:FF")
 
         redis_key = client.rule_key(device_id, mac_address.value)
-        expected = "%s.%s" % (device_id, "aabbccddeeff")
+        expected = "%s.%s/sg" % (device_id, "aabbccddeeff")
         self.assertEqual(expected, redis_key)
         conn_pool.assert_called_with(host=host, port=port)
 
@@ -268,10 +268,10 @@ class TestRedisForAgent(test_base.TestBase):
                            VIF(7, 8, 2)])
         group_uuids = rc.get_security_groups(new_interfaces)
         mock_pipeline.get.assert_has_calls(
-            [mock.call("1.000000000002"),
-             mock.call("3.000000000004"),
-             mock.call("5.000000000006"),
-             mock.call("7.000000000008")],
+            [mock.call("1.000000000002/sg"),
+             mock.call("3.000000000004/sg"),
+             mock.call("5.000000000006/sg"),
+             mock.call("7.000000000008/sg")],
             any_order=True)
         mock_pipeline.execute.assert_called_once_with()
         self.assertEqual(group_uuids,


### PR DESCRIPTION
Changes the security groups schema slightly to be a sub-key of
$INSTANCE_UUID.$MAC_ADDRESS/sg