### PR TITLE
Revert "eager-loading of associations relationship on IPAddress model"

### DIFF
--- a/quark/db/models.py
+++ b/quark/db/models.py
@@ -160,8 +160,7 @@ class IPAddress(BASEV2, models.HasId):
     address_type = sa.Column(sa.Enum(ip_types.FIXED, ip_types.FLOATING,
                                      ip_types.SHARED,
                              name="quark_ip_address_types"))
-    associations = orm.relationship(PortIpAssociation, backref="ip_address",
-                                    lazy='subquery')
+    associations = orm.relationship(PortIpAssociation, backref="ip_address")
 
     def enabled_for_port(self, port):
         for assoc in self["associations"]:


### PR DESCRIPTION
This reverts commit 494a3a4ddc1d7819e761df5eb0bc080b0c877337.

Determined that lazy='subquery' on the associations attribute of the
IPAddress model was substantially increasing the volume of
DBDeadLock errors and thusly degrading API performance. This is to
revert that model change. There were many reverts of this before for
producing test packages. This is intended to be the final removal of
this commit.

RM11222