### PR TITLE
Reverts RM10879

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -485,41 +485,9 @@ def subnet_find_ordered_by_most_full(context, net_id, **filters):
         query = query.filter(models.Subnet.ip_version == filters["ip_version"])
     if "segment_id" in filters and filters["segment_id"]:
         query = query.filter(models.Subnet.segment_id == filters["segment_id"])
-    query = query.filter(models.Subnet.next_auto_assign_ip != -1)
-
     if "subnet_id" in filters and filters["subnet_id"]:
         query = query.filter(models.Subnet.id.in_(filters["subnet_id"]))
-    return query
-
-
-def subnet_update_next_auto_assign_ip(context, subnet):
-    query = context.session.query(models.Subnet)
-    query = query.filter(models.Subnet.id == subnet["id"])
     query = query.filter(models.Subnet.next_auto_assign_ip != -1)
-
-    # For details on synchronize_session, see:
-    # http://docs.sqlalchemy.org/en/rel_0_8/orm/query.html
-    query = query.update(
-        {"next_auto_assign_ip":
-         models.Subnet.next_auto_assign_ip + 1},
-        synchronize_session=False)
-
-    # Returns a count of the rows matched in the update
-    return query
-
-
-def subnet_update_set_full(context, subnet):
-    query = context.session.query(models.Subnet)
-    query = query.filter_by(id=subnet["id"])
-    query = query.filter(models.Subnet.next_auto_assign_ip != -1)
-
-    # For details on synchronize_session, see:
-    # http://docs.sqlalchemy.org/en/rel_0_8/orm/query.html
-    query = query.update(
-        {"next_auto_assign_ip": -1},
-        synchronize_session=False)
-
-    # Returns a count of the rows matched in the update
     return query
 
 

--- a/quark/db/custom_types.py
+++ b/quark/db/custom_types.py
@@ -34,16 +34,6 @@ class INET(types.TypeDecorator):
             return value
         return long(value)
 
-    def coerce_compared_value(self, op, value):
-        # NOTE(mdietz): If left unimplemented, the column is coerced into a
-        # string every time, causing the next_auto_assign_increment to be a
-        # string concatenation rather than an addition. 'value' in the
-        # signature is the "other" value being compared for the purposes of
-        # casting.
-        if isinstance(value, int):
-            return types.Integer()
-        return self
-
 
 class MACAddress(types.TypeDecorator):
     impl = types.BigInteger

--- a/quark/ipam.py
+++ b/quark/ipam.py
@@ -692,68 +692,60 @@ class QuarkIpam(object):
                                 segment_id=segment_id, subnet_ids=subnet_ids,
                                 ip_version=filters.get("ip_version"))))
 
-        with context.session.begin():
-            subnets = db_api.subnet_find_ordered_by_most_full(
-                context, net_id, segment_id=segment_id, scope=db_api.ALL,
-                subnet_id=subnet_ids, **filters)
+        subnets = db_api.subnet_find_ordered_by_most_full(
+            context, net_id, segment_id=segment_id, scope=db_api.ALL,
+            subnet_id=subnet_ids, **filters)
 
-            if not subnets:
-                LOG.info("No subnets found given the search criteria!")
+        if not subnets:
+            LOG.info("No subnets found given the search criteria!")
 
-            for subnet, ips_in_subnet in subnets:
-                ipnet = netaddr.IPNetwork(subnet["cidr"])
-                LOG.info("Trying subnet ID: {0} - CIDR: {1}".format(
-                    subnet["id"], subnet["_cidr"]))
-                if ip_address:
-                    na_ip = netaddr.IPAddress(ip_address)
-                    if ipnet.version == 4 and na_ip.version != 4:
-                        na_ip = na_ip.ipv4()
-                    if na_ip not in ipnet:
-                        if subnet_ids is not None:
-                            LOG.info("Requested IP {0} not in subnet {1}, "
-                                     "retrying".format(str(na_ip), str(ipnet)))
-                            raise q_exc.IPAddressNotInSubnet(
-                                ip_addr=ip_address, subnet_id=subnet["id"])
-                        continue
+        for subnet, ips_in_subnet in subnets:
+            ipnet = netaddr.IPNetwork(subnet["cidr"])
+            LOG.info("Trying subnet ID: {0} - CIDR: {1}".format(
+                subnet["id"], subnet["_cidr"]))
+            if ip_address:
+                na_ip = netaddr.IPAddress(ip_address)
+                if ipnet.version == 4 and na_ip.version != 4:
+                    na_ip = na_ip.ipv4()
+                if na_ip not in ipnet:
+                    if subnet_ids is not None:
+                        LOG.info("Requested IP {0} not in subnet {1}, "
+                                 "retrying".format(str(na_ip), str(ipnet)))
+                        raise q_exc.IPAddressNotInSubnet(
+                            ip_addr=ip_address, subnet_id=subnet["id"])
+                    continue
 
-                ip_policy = None
+            ip_policy = None
+            if not ip_address:
+                # Policies don't prevent explicit assignment, so we only
+                # need to check if we're allocating a new IP
+                ip_policy = subnet.get("ip_policy")
+
+            policy_size = ip_policy["size"] if ip_policy else 0
+
+            if ipnet.size > (ips_in_subnet + policy_size - 1):
                 if not ip_address:
-                    # Policies don't prevent explicit assignment, so we only
-                    # need to check if we're allocating a new IP
-                    ip_policy = subnet.get("ip_policy")
+                    ip = subnet["next_auto_assign_ip"]
+                    # If ip is somehow -1 in here don't touch it anymore
+                    if ip != -1:
+                        ip += 1
+                    # and even then if it is outside the valid range set it to
+                    # -1 to be safe
+                    if ip < subnet["first_ip"] or ip > subnet["last_ip"]:
+                        LOG.info("Marking subnet {0} as full".format(
+                            subnet["id"]))
+                        ip = -1
+                    self._set_subnet_next_auto_assign_ip(context, subnet, ip)
+                LOG.info("Subnet {0} - {1} looks viable, returning".format(
+                    subnet["id"], subnet["_cidr"]))
+                return subnet
+            else:
+                LOG.info("Marking subnet {0} as full".format(subnet["id"]))
+                self._set_subnet_next_auto_assign_ip(context, subnet, -1)
 
-                policy_size = ip_policy["size"] if ip_policy else 0
-
-                if ipnet.size > (ips_in_subnet + policy_size - 1):
-                    if not ip_address:
-                        ip = subnet["next_auto_assign_ip"]
-                        # NOTE(mdietz): When atomically updated, this probably
-                        #               doesn't need the lower bounds check but
-                        #               I'm not comfortable removing it yet.
-                        if ip < subnet["first_ip"] or ip > subnet["last_ip"]:
-                            LOG.info("Marking subnet {0} as full".format(
-                                subnet["id"]))
-                            updated = db_api.subnet_update_set_full(context,
-                                                                    subnet)
-                        else:
-                            updated = db_api.subnet_update_next_auto_assign_ip(
-                                context, subnet)
-
-                        if updated:
-                            context.session.refresh(subnet)
-                        else:
-                            # This means the subnet was marked full while
-                            # we were checking out policies. Fall out and
-                            # go back to the outer retry loop.
-                            return
-
-                    LOG.info("Subnet {0} - {1} {2} looks viable, "
-                             "returning".format(subnet["id"], subnet["_cidr"],
-                                                subnet["next_auto_assign_ip"]))
-                    return subnet
-                else:
-                    LOG.info("Marking subnet {0} as full".format(subnet["id"]))
-                    db_api.subnet_update_set_full(context, subnet)
+    def _set_subnet_next_auto_assign_ip(self, context, subnet, ip):
+        with context.session.begin():
+            db_api.subnet_update(context, subnet, next_auto_assign_ip=ip)
 
 
 class QuarkIpamANY(QuarkIpam):

--- a/quark/tests/functional/db/test_api.py
+++ b/quark/tests/functional/db/test_api.py
@@ -157,37 +157,6 @@ class QuarkFindSubnetAllocationCount(QuarkIpamBaseFunctionalTest):
             self.assertEqual(subnets[0][0].ip_version, 4)
             self.assertEqual(subnets[1][0].ip_version, 6)
 
-    def test_subnet_set_full(self):
-        cidr4 = "0.0.0.0/30"  # 2 bits
-        net4 = netaddr.IPNetwork(cidr4)
-        with self._fixtures([
-            self._create_models(cidr4, 4, net4[0])
-        ]) as net:
-            subnet = db_api.subnet_find(self.context, network_id=net['id'],
-                                        scope=db_api.ALL)[0]
-            with self.context.session.begin():
-                updated = db_api.subnet_update_set_full(self.context, subnet)
-                self.context.session.refresh(subnet)
-                self.assertTrue(updated)
-                self.assertEqual(subnet["next_auto_assign_ip"], -1)
-
-    def test_subnet_update_next_auto_assign_ip(self):
-        cidr4 = "0.0.0.0/30"  # 2 bits
-        net4 = netaddr.IPNetwork(cidr4)
-        with self._fixtures([
-            self._create_models(cidr4, 4, net4[0])
-        ]) as net:
-            subnet = db_api.subnet_find(self.context, network_id=net['id'],
-                                        scope=db_api.ALL)[0]
-            with self.context.session.begin():
-                updated = db_api.subnet_update_next_auto_assign_ip(
-                    self.context, subnet)
-                self.context.session.refresh(subnet)
-                self.assertTrue(updated)
-                self.assertEqual(
-                    netaddr.IPAddress(subnet["next_auto_assign_ip"]).ipv4(),
-                    net4[1])
-
 
 class QuarkFindMacAddressRangeAllocationCount(QuarkIpamBaseFunctionalTest):
     @contextlib.contextmanager

--- a/quark/tests/test_ipam.py
+++ b/quark/tests/test_ipam.py
@@ -448,12 +448,8 @@ class QuarkIpamTestBothIpAllocation(QuarkIpamBaseTest):
         with contextlib.nested(
             mock.patch("quark.db.api.ip_address_find"),
             mock.patch("quark.db.api.subnet_find_ordered_by_most_full"),
-            mock.patch("quark.db.api.subnet_find"),
-            mock.patch("quark.db.api.subnet_update_next_auto_assign_ip"),
-            mock.patch("quark.db.api.subnet_update_set_full"),
-            mock.patch("sqlalchemy.orm.session.Session.refresh")
-        ) as (addr_find, subnet_alloc_find, subnet_find, subnet_update,
-              subnet_set_full, refresh):
+            mock.patch("quark.db.api.subnet_find")
+        ) as (addr_find, subnet_alloc_find, subnet_find):
             addr_mods = []
             sub_mods = []
             for a in addresses:
@@ -476,19 +472,6 @@ class QuarkIpamTestBothIpAllocation(QuarkIpamBaseTest):
             if sub_mods and len(sub_mods[0]):
                 subnet_find.return_value = [sub_mods[0][0][0]]
             subnet_alloc_find.side_effect = sub_mods
-            subnet_update.return_value = 1
-
-            def refresh_mock(sub):
-                if sub["next_auto_assign_ip"] >= 0:
-                    sub["next_auto_assign_ip"] += 1
-
-            def set_full_mock(context, sub):
-                sub["next_auto_assign_ip"] = -1
-                return 1
-
-            refresh.side_effect = refresh_mock
-            subnet_set_full.side_effect = set_full_mock
-
             yield
 
     def test_allocate_new_ip_address_unmarked_negative_one_full_subnet(self):
@@ -503,7 +486,7 @@ class QuarkIpamTestBothIpAllocation(QuarkIpamBaseTest):
                          next_auto_assign_ip=255,
                          ip_policy=dict(size=2))
         net3 = netaddr.IPNetwork("2.2.2.0/24")
-        subnet4_3 = dict(id=3, first_ip=net3.first, last_ip=net3.last,
+        subnet4_3 = dict(id=2, first_ip=net3.first, last_ip=net3.last,
                          cidr=net3.cidr, ip_version=net3.version,
                          next_auto_assign_ip=255,
                          ip_policy=dict(size=2))
@@ -830,11 +813,8 @@ class QuarkIpamTestBothRequiredIpAllocation(QuarkIpamBaseTest):
         self.context.session.add = mock.Mock()
         with contextlib.nested(
             mock.patch("quark.db.api.ip_address_find"),
-            mock.patch("quark.db.api.subnet_find_ordered_by_most_full"),
-            mock.patch("quark.db.api.subnet_update_next_auto_assign_ip"),
-            mock.patch("quark.db.api.subnet_update_set_full"),
-            mock.patch("sqlalchemy.orm.session.Session.refresh")
-        ) as (addr_find, subnet_find, subnet_update, subnet_set_full, refresh):
+            mock.patch("quark.db.api.subnet_find_ordered_by_most_full")
+        ) as (addr_find, subnet_find):
             addr_find.side_effect = [ip_helper(a) for a in addresses]
             sub_mods = []
             for sub_list in subnets:
@@ -850,19 +830,6 @@ class QuarkIpamTestBothRequiredIpAllocation(QuarkIpamBaseTest):
 
                 sub_mods.append(sub_mod_list)
             subnet_find.side_effect = sub_mods
-            subnet_update.return_value = 1
-
-            def refresh_mock(sub):
-                if sub["next_auto_assign_ip"] != -1:
-                    sub["next_auto_assign_ip"] += 1
-
-            def set_full_mock(context, sub):
-                sub["next_auto_assign_ip"] = -1
-                return 1
-
-            refresh.side_effect = refresh_mock
-            subnet_set_full.side_effect = set_full_mock
-
             yield
 
     def test_allocate_new_ip_address_two_empty_subnets(self):
@@ -1192,11 +1159,8 @@ class QuarkNewIPAddressAllocation(QuarkIpamBaseTest):
         self.context.session.add = mock.Mock()
         with contextlib.nested(
             mock.patch("quark.db.api.ip_address_find"),
-            mock.patch("quark.db.api.subnet_find_ordered_by_most_full"),
-            mock.patch("quark.db.api.subnet_update_next_auto_assign_ip"),
-            mock.patch("quark.db.api.subnet_update_set_full"),
-            mock.patch("sqlalchemy.orm.session.Session.refresh")
-        ) as (addr_find, subnet_find, subnet_update, subnet_set_full, refresh):
+            mock.patch("quark.db.api.subnet_find_ordered_by_most_full")
+        ) as (addr_find, subnet_find):
             addr_find.side_effect = [ip_helper(a) for a in addresses]
             if isinstance(subnets, list):
                 subnet_find.return_value = [(subnet_helper(s), c)
@@ -1216,18 +1180,6 @@ class QuarkNewIPAddressAllocation(QuarkIpamBaseTest):
                             sub_mod_list.append(sub)
                     sub_mods.append(sub_mod_list)
                 subnet_find.side_effect = sub_mods
-
-            subnet_update.return_value = 1
-
-            def refresh_mock(sub):
-                sub["next_auto_assign_ip"] += 1
-
-            def set_full_mock(context, sub):
-                sub["next_auto_assign_ip"] = -1
-                return 1
-
-            refresh.side_effect = refresh_mock
-            subnet_set_full.side_effect = set_full_mock
             yield
 
     def test_allocate_new_ip_address_in_empty_subnet(self):
@@ -1455,12 +1407,8 @@ class QuarkIPAddressAllocationTestRetries(QuarkIpamBaseTest):
             mock.patch("quark.db.api.ip_address_find"),
             mock.patch("quark.db.api.ip_address_create"),
             mock.patch("quark.ipam.QuarkIpam._notify_new_addresses"),
-            mock.patch("quark.db.api.subnet_find_ordered_by_most_full"),
-            mock.patch("quark.db.api.subnet_update_next_auto_assign_ip"),
-            mock.patch("quark.db.api.subnet_update_set_full"),
-            mock.patch("sqlalchemy.orm.session.Session.refresh")
-        ) as (addr_find, addr_create, notify, subnet_find, subnet_update,
-              subnet_set_full, refresh):
+            mock.patch("quark.db.api.subnet_find_ordered_by_most_full")
+        ) as (addr_find, addr_create, notify, subnet_find):
             addr_find.side_effect = [None, None, None]
             addr_mods = []
             for a in address:
@@ -1474,17 +1422,6 @@ class QuarkIPAddressAllocationTestRetries(QuarkIpamBaseTest):
                 for sub, count in subnets:
                     sub_mods.append((subnet_helper(sub), count))
             subnet_find.return_value = sub_mods
-            subnet_update.return_value = 1
-
-            def refresh_mock(sub):
-                sub["next_auto_assign_ip"] += 1
-
-            def set_full_mock(context, sub):
-                sub["next_auto_assign_ip"] = -1
-                return 1
-
-            refresh.side_effect = refresh_mock
-            subnet_set_full.side_effect = set_full_mock
             yield sub_mods, addr_mods
 
     def test_allocate_allocated_ip_fails_and_retries(self):
@@ -1565,10 +1502,8 @@ class QuarkIPAddressAllocationTestRetries(QuarkIpamBaseTest):
                     self.context, [], 0, 0, 0, ip_addresses=["0.0.1.0"],
                     subnets=subnet1)
 
-    def test_allocate_last_ip_allocates(self):
-        # NOTE(mdietz): test originally checked if the subnet closed. Now
-        #               we're letting the next allocation take care of it
-        subnet1 = dict(id=1, first_ip=0, last_ip=1, next_auto_assign_ip=1,
+    def test_allocate_last_ip_closes_subnet(self):
+        subnet1 = dict(id=1, first_ip=0, last_ip=1, next_auto_assign_ip=2,
                        cidr="0.0.0.0/31", ip_version=4,
                        ip_policy=None)
         subnets = [(subnet1, 1)]
@@ -1577,6 +1512,8 @@ class QuarkIPAddressAllocationTestRetries(QuarkIpamBaseTest):
                                                                     addr_mods):
             addr = []
             self.ipam.allocate_ip_address(self.context, addr, 0, 0, 0)
+            closed_sub = sub_mods[0][0]
+            self.assertEqual(closed_sub["next_auto_assign_ip"], -1)
             self.assertEqual(addr[0]["address"], 1)
 
 
@@ -1667,28 +1604,14 @@ class TestQuarkIpPoliciesIpAllocation(QuarkIpamBaseTest):
         self.context.session.add = mock.Mock()
         with contextlib.nested(
             mock.patch("quark.db.api.ip_address_find"),
-            mock.patch("quark.db.api.subnet_find_ordered_by_most_full"),
-            mock.patch("quark.db.api.subnet_update_next_auto_assign_ip"),
-            mock.patch("quark.db.api.subnet_update_set_full"),
-            mock.patch("sqlalchemy.orm.session.Session.refresh")
-        ) as (addr_find, subnet_find, subnet_update, subnet_set_full, refresh):
+            mock.patch("quark.db.api.subnet_find_ordered_by_most_full")
+        ) as (addr_find, subnet_find):
             addr_find.side_effect = [ip_helper(a) for a in addresses]
             sub_mods = []
             if subnets:
                 for sub, count in subnets:
                     sub_mods.append((subnet_helper(sub), count))
             subnet_find.return_value = sub_mods
-            subnet_update.return_value = 1
-
-            def refresh_mock(sub):
-                sub["next_auto_assign_ip"] += 1
-
-            def set_full_mock(context, sub):
-                sub["next_auto_assign_ip"] = -1
-                return 1
-
-            refresh.side_effect = refresh_mock
-            subnet_set_full.side_effect = set_full_mock
             yield
 
     def test_first_ip_is_not_network_ip_by_default(self):
@@ -1769,12 +1692,9 @@ class QuarkIPAddressAllocationNotifications(QuarkIpamBaseTest):
             mock.patch("quark.db.api.ip_address_find"),
             mock.patch("quark.db.api.ip_address_create"),
             mock.patch("quark.db.api.subnet_find_ordered_by_most_full"),
-            mock.patch("quark.db.api.subnet_update_next_auto_assign_ip"),
-            mock.patch("sqlalchemy.orm.session.Session.refresh"),
             mock.patch("neutron.common.rpc.get_notifier"),
             mock.patch("oslo.utils.timeutils.utcnow"),
-        ) as (addr_find, addr_create, subnet_find, subnet_update, refresh,
-              notify, time):
+        ) as (addr_find, addr_create, subnet_find, notify, time):
             addrs_found = []
             for a in addresses:
                 if a:
@@ -1789,15 +1709,13 @@ class QuarkIPAddressAllocationNotifications(QuarkIpamBaseTest):
                     sub_mods.append((subnet_helper(sub), count))
 
             subnet_find.return_value = sub_mods
-            subnet_update.return_value = 1
-            refresh.return_value = sub_mods
             time.return_value = deleted_at
             yield notify
 
     def test_allocation_notification(self):
         subnet = dict(id=1, first_ip=0, last_ip=255,
                       cidr="0.0.0.0/24", ip_version=4,
-                      next_auto_assign_ip=1,
+                      next_auto_assign_ip=0,
                       ip_policy=None)
         address = dict(address=0, created_at="123", subnet_id=1,
                        address_readable="0.0.0.0", used_by_tenant_id=1)
@@ -1872,96 +1790,3 @@ class QuarkIpamTestV6IpGeneration(QuarkIpamBaseTest):
         ip = gen.next()
         self.assertEqual(ip,
                          netaddr.IPAddress('fe80::40c9:a95:d83a:2ffa').value)
-
-
-class QuarkIpamTestSelectSubnet(QuarkIpamBaseTest):
-    @contextlib.contextmanager
-    def _stubs(self, subnet, count, increments=True, marks_full=True):
-        with contextlib.nested(
-            mock.patch("quark.db.api.subnet_find_ordered_by_most_full"),
-            mock.patch("quark.db.api.subnet_update_next_auto_assign_ip"),
-            mock.patch("quark.db.api.subnet_update_set_full"),
-            mock.patch("sqlalchemy.orm.session.Session.refresh"),
-        ) as (subnet_find, subnet_incr, subnet_set_full, refresh):
-            sub_mods = []
-            sub_mods.append((subnet_helper(subnet), count))
-
-            def subnet_increment(context, sub):
-                if increments:
-                    sub["next_auto_assign_ip"] += 1
-                    return True
-                return False
-
-            def set_full_mock(context, sub):
-                if marks_full:
-                    sub["next_auto_assign_ip"] = -1
-                    return True
-                return False
-
-            subnet_find.return_value = sub_mods
-            subnet_incr.side_effect = subnet_increment
-            subnet_set_full.side_effect = set_full_mock
-            yield sub_mods, refresh
-
-    def test_select_subnet_incremement_next_auto_assign(self):
-        subnet = dict(id=1, first_ip=0, last_ip=255,
-                      cidr="0.0.0.0/24", ip_version=4,
-                      next_auto_assign_ip=1,
-                      ip_policy=None, network_id=1)
-        with self._stubs(subnet, 1) as (subnets, refresh):
-            s = self.ipam.select_subnet(self.context, subnet["network_id"],
-                                        None, None)
-            self.assertEqual(subnets[0][0], s)
-            self.assertEqual(subnets[0][0]["next_auto_assign_ip"], 2)
-
-    def test_select_subnet_increment_fails(self):
-        subnet = dict(id=1, first_ip=0, last_ip=255,
-                      cidr="0.0.0.0/24", ip_version=4,
-                      next_auto_assign_ip=1,
-                      ip_policy=None, network_id=1)
-        with self._stubs(subnet, 1, increments=False) as (subnets, refresh):
-            s = self.ipam.select_subnet(self.context, subnet["network_id"],
-                                        None, None)
-            self.assertEqual(s, None)
-            self.assertEqual(subnets[0][0]["next_auto_assign_ip"], 1)
-
-    def test_select_subnet_set_subnet_full(self):
-        net = netaddr.IPNetwork("0.0.0.0/24")
-        subnet = dict(id=1, first_ip=0, last_ip=net.last,
-                      cidr=str(net), ip_version=4,
-                      next_auto_assign_ip=net.last + 1,
-                      ip_policy=None, network_id=1)
-        with self._stubs(subnet, net.size, increments=False) as (subnets,
-                                                                 refresh):
-            s = self.ipam.select_subnet(self.context, subnet["network_id"],
-                                        None, None)
-            self.assertEqual(subnets[0][0], s)
-            self.assertEqual(subnets[0][0]["next_auto_assign_ip"], -1)
-
-    def test_select_subnet_set_full_already_full(self):
-        net = netaddr.IPNetwork("0.0.0.0/24")
-        subnet = dict(id=1, first_ip=0, last_ip=net.last,
-                      cidr=str(net), ip_version=4,
-                      next_auto_assign_ip=net.last + 1,
-                      ip_policy=None, network_id=1)
-        with self._stubs(subnet, net.size, marks_full=False) as (subnets,
-                                                                 refresh):
-            s = self.ipam.select_subnet(self.context, subnet["network_id"],
-                                        None, None)
-            self.assertEqual(None, s)
-            self.assertFalse(refresh.called)
-
-    def test_select_subnet_set_subnet_full_because_policies(self):
-        net = netaddr.IPNetwork("0.0.0.0/24")
-        subnet = dict(id=1, first_ip=0, last_ip=net.last,
-                      cidr=str(net), ip_version=4, network_id=1,
-                      next_auto_assign_ip=net.last + 1,
-                      ip_policy=dict(size=1, exclude=[
-                          models.IPPolicyCIDR(cidr="0.0.0.0/24")]))
-
-        with self._stubs(subnet, net.size) as (subnets, refresh):
-            s = self.ipam.select_subnet(self.context, subnet["network_id"],
-                                        None, None)
-            self.assertEqual(None, s)
-            self.assertFalse(refresh.called)
-            self.assertEqual(subnets[0][0]["next_auto_assign_ip"], -1)


### PR DESCRIPTION
This is the patch that fixes the TOCTOU bug. However, I apparently
failed to test what happens with v6 subnets. The problem is MySQL has no
native 128 bit type. Rather than trying to patch it as is, I decided to
revert this patch and revisit as a whole.