### PR TITLE
Fixes multiple Exception signatures

### DIFF
--- a/quark/plugin_modules/security_groups.py
+++ b/quark/plugin_modules/security_groups.py
@@ -91,7 +91,7 @@ def create_security_group_rule(context, security_group_rule):
         group = db_api.security_group_find(context, id=group_id,
                                            scope=db_api.ONE)
         if not group:
-            raise sg_ext.SecurityGroupNotFound(group_id=group_id)
+            raise sg_ext.SecurityGroupNotFound(id=group_id)
 
         quota.QUOTAS.limit_check(
             context, context.tenant_id,
@@ -110,7 +110,7 @@ def delete_security_group(context, id):
 
         # TODO(anyone): name and ports are lazy-loaded. Could be good op later
         if not group:
-            raise sg_ext.SecurityGroupNotFound(group_id=id)
+            raise sg_ext.SecurityGroupNotFound(id=id)
         if id == DEFAULT_SG_UUID or group.name == "default":
             raise sg_ext.SecurityGroupCannotRemoveDefault()
         if group.ports:
@@ -125,7 +125,7 @@ def delete_security_group_rule(context, id):
         rule = db_api.security_group_rule_find(context, id=id,
                                                scope=db_api.ONE)
         if not rule:
-            raise sg_ext.SecurityGroupRuleNotFound(group_id=id)
+            raise sg_ext.SecurityGroupRuleNotFound(id=id)
 
         group = db_api.security_group_find(context, id=rule["group_id"],
                                            scope=db_api.ONE)
@@ -141,7 +141,7 @@ def get_security_group(context, id, fields=None):
              (id, context.tenant_id))
     group = db_api.security_group_find(context, id=id, scope=db_api.ONE)
     if not group:
-        raise sg_ext.SecurityGroupNotFound(group_id=id)
+        raise sg_ext.SecurityGroupNotFound(id=id)
     return v._make_security_group_dict(group, fields)
 
 
@@ -151,7 +151,7 @@ def get_security_group_rule(context, id, fields=None):
     rule = db_api.security_group_rule_find(context, id=id,
                                            scope=db_api.ONE)
     if not rule:
-        raise sg_ext.SecurityGroupRuleNotFound(rule_id=id)
+        raise sg_ext.SecurityGroupRuleNotFound(id=id)
     return v._make_security_group_rule_dict(rule, fields)
 
 


### PR DESCRIPTION
RM11250

Updates the security groups plugin to properly instantiate the
exceptions being raised. The bug was two fold:

When testing with neutronclient, it always issues a GET
/<resource>?id=<uuid> on the resource, returning an empty list if
the security group or rule in question doesn't exist. In those cases,
the DELETE or GET as appropriate were never called on the routes where
the exceptions were being raised incorrectly.

Secondly, tests passed because of save_and_reraise in Neutron, which
would reraise our SecurityGroupNotFound and SecurityGroupRuleNotFound
exceptions, allowing the tests looking for those to pass. However, the
message included with those exceptions was the traceback of the
respective exceptions failing to instantiate, rather than the expected
message.