### PR TITLE
Changes use of messaging to oslo_messaging

### DIFF
--- a/quark/tests/functional/db/test_api.py
+++ b/quark/tests/functional/db/test_api.py
@@ -28,7 +28,7 @@ class QuarkIpamBaseFunctionalTest(BaseFunctionalTest):
     def setUp(self):
         super(QuarkIpamBaseFunctionalTest, self).setUp()
 
-        patcher = mock.patch("neutron.common.rpc.messaging")
+        patcher = mock.patch("neutron.common.rpc.oslo_messaging")
         patcher.start()
         self.addCleanup(patcher.stop)
         rpc.init(mock.MagicMock())

--- a/quark/tests/functional/plugin_modules/test_networks.py
+++ b/quark/tests/functional/plugin_modules/test_networks.py
@@ -31,7 +31,7 @@ class QuarkNetworkFunctionalTest(BaseFunctionalTest):
     def setUp(self):
         super(QuarkNetworkFunctionalTest, self).setUp()
 
-        patcher = mock.patch("neutron.common.rpc.messaging")
+        patcher = mock.patch("neutron.common.rpc.oslo_messaging")
         patcher.start()
         self.addCleanup(patcher.stop)
         rpc.init(mock.MagicMock())

--- a/quark/tests/functional/test_ipam.py
+++ b/quark/tests/functional/test_ipam.py
@@ -32,7 +32,7 @@ class QuarkIpamBaseFunctionalTest(BaseFunctionalTest):
     def setUp(self):
         super(QuarkIpamBaseFunctionalTest, self).setUp()
 
-        patcher = mock.patch("neutron.common.rpc.messaging")
+        patcher = mock.patch("neutron.common.rpc.oslo_messaging")
         patcher.start()
         self.addCleanup(patcher.stop)
         rpc.init(mock.MagicMock())

--- a/quark/tests/test_ipam.py
+++ b/quark/tests/test_ipam.py
@@ -78,7 +78,7 @@ class QuarkIpamBaseTest(test_base.TestBase):
     def setUp(self):
         super(QuarkIpamBaseTest, self).setUp()
 
-        patcher = mock.patch("neutron.common.rpc.messaging")
+        patcher = mock.patch("neutron.common.rpc.oslo_messaging")
         patcher.start()
         self.addCleanup(patcher.stop)
         rpc.init(mock.MagicMock())


### PR DESCRIPTION
An upstream neutron change moved neutron.common.rpc.messaging to
neutron.common.rpc.oslo_messaging, breaking several of our unit test
modules. This patch changes the mocks to compensate.