### PR TITLE
Re-points the entrypoint for redis_sg_tool

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,4 +26,4 @@ console_scripts =
     gunicorn-neutron-server = quark.gunicorn_server:main
     quark-agent = quark.agent.agent:main
     ip_availability = quark.ip_availability:main
-    redis_sg_tool = quark.security_groups.redis_sg_tool:main
+    redis_sg_tool = quark.tools.redis_sg_tool:main


### PR DESCRIPTION
RM11375

A recent refactoring moved redis_sg_tool and forgot to give it an
__init__.py to make it properly import and also forgot to ticket the
entrypoint.