### PR TITLE
Fixes building the tox venv after upstream change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.7"
   - "2.6"
+before_install:
+  - "export NO_EVENTLET=1"
 install:
   - pip install -r requirements.txt -r test-requirements.txt . --use-mirrors
 before_script:

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ setenv = VIRTUAL_ENV={envdir}
          NOSE_OPENSTACK_YELLOW=0.025
          NOSE_OPENSTACK_SHOW_ELAPSED=1
          NOSE_OPENSTACK_STDOUT=1
+         NO_EVENTLET=1
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands = nosetests {posargs}


### PR DESCRIPTION
Upstream change https://github.com/openstack/neutron/commit/dea4755
supplied a new environment variable NO_EVENTLET that causes all sorts of
shenanigans when building a venv including neutron. Adding it to quark's
tox.ini fixes it.