### PR TITLE
Added GET /ip_availabilities API

### DIFF
--- a/quark/api/extensions/ip_availability.py
+++ b/quark/api/extensions/ip_availability.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2015 OpenStack Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from neutron.api import extensions
+from neutron.common import exceptions
+from neutron import manager
+from neutron.openstack.common import log as logging
+from neutron import wsgi
+
+RESOURCE_NAME = "ip_availability"
+RESOURCE_COLLECTION = "ip_availabilities"
+EXTENDED_ATTRIBUTES_2_0 = {
+    RESOURCE_COLLECTION: {}
+}
+
+attr_dict = EXTENDED_ATTRIBUTES_2_0[RESOURCE_COLLECTION]
+attr_dict[RESOURCE_NAME] = {'allow_post': False,
+                            'allow_put': False,
+                            'is_visible': True}
+
+LOG = logging.getLogger(__name__)
+
+
+class IPAvailabilityController(wsgi.Controller):
+    def __init__(self, plugin):
+        self._resource_name = RESOURCE_NAME
+        self._plugin = plugin
+
+    def index(self, request):
+        context = request.context
+        if not context.is_admin:
+            raise exceptions.NotAuthorized()
+        return self._plugin.get_ip_availability(**request.GET)
+
+
+class Ip_availability(object):
+    """IP Availability support."""
+    @classmethod
+    def get_name(cls):
+        return "IP Availability for a Neutron deployment"
+
+    @classmethod
+    def get_alias(cls):
+        return RESOURCE_COLLECTION
+
+    @classmethod
+    def get_description(cls):
+        return ("Expose functions for cloud admin to get IP availability")
+
+    @classmethod
+    def get_namespace(cls):
+        return ("http://docs.openstack.org/network/ext/"
+                "ip-availability/api/v2.0")
+
+    @classmethod
+    def get_updated(cls):
+        return "2015-02-18T00:00:00-00:00"
+
+    def get_extended_resources(self, version):
+        if version == "2.0":
+            return EXTENDED_ATTRIBUTES_2_0
+        else:
+            return {}
+
+    @classmethod
+    def get_resources(cls):
+        """Returns Ext Resources."""
+        plugin = manager.NeutronManager.get_plugin()
+        controller = IPAvailabilityController(plugin)
+        return [extensions.ResourceExtension(Ip_availability.get_alias(),
+                                             controller)]

--- a/quark/ip_availability.py
+++ b/quark/ip_availability.py
@@ -46,7 +46,7 @@ def main():
 
 
 def get_ip_availability(**kwargs):
-    LOG.debug("Begin querying")
+    LOG.debug("Begin querying %s" % kwargs)
     used_ips = get_used_ips(neutron_db_api.get_session(), **kwargs)
     unused_ips = get_unused_ips(neutron_db_api.get_session(), used_ips,
                                 **kwargs)

--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -24,6 +24,7 @@ from neutron import quota
 from oslo.config import cfg
 
 from quark.api import extensions
+from quark import ip_availability
 from quark.plugin_modules import ip_addresses
 from quark.plugin_modules import ip_policies
 from quark.plugin_modules import mac_address_ranges
@@ -117,7 +118,8 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
                                    "security-group", "diagnostics",
                                    "subnets_quark", "provider",
                                    "ip_policies", "quotas",
-                                   "networks_quark", "router"]
+                                   "networks_quark", "router",
+                                   "ip_availabilities"]
 
     def __init__(self):
         LOG.info("Starting quark plugin")
@@ -400,3 +402,6 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
 
     def get_floatingips_count(self, context, filters=None):
         raise NotImplementedError()
+
+    def get_ip_availability(self, **kwargs):
+        return ip_availability.get_ip_availability(**kwargs)


### PR DESCRIPTION
Currently, only single value per parameter is able to be specified
due to limitations of the resource handler. For example, GET
/ip_availabilities?ip_version=4&ip_version=6 will only pass in the
filter for ip_version equal to 6.

RM7008