### PR TITLE
Refactors RM11449

### DIFF
--- a/quark/cache/security_groups_client.py
+++ b/quark/cache/security_groups_client.py
@@ -169,6 +169,12 @@ class SecurityGroupsClient(redis_base.ClientBase):
 
         Returns a dictionary of xapi.VIFs with values of the current
         acknowledged status in Redis.
+
+        States not explicitly handled:
+        * ack key, no rules - This is the same as just tagging the VIF,
+          the instance will be inaccessible
+        * rules key, no ack - Nothing will happen, the VIF will
+          not be tagged.
         """
         LOG.debug("Getting security groups from Redis for {0}".format(
             interfaces))
@@ -179,15 +185,15 @@ class SecurityGroupsClient(redis_base.ClientBase):
         security_groups = self.get_fields(vif_keys, SECURITY_GROUP_ACK)
 
         ret = {}
-        for vif, security_group in zip(interfaces, security_groups):
-            if security_group:
-                security_group = security_group.lower()
-                if "true" in security_group:
+        for vif, security_group_ack in zip(interfaces, security_groups):
+            if security_group_ack:
+                security_group_ack = security_group_ack.lower()
+                if "true" in security_group_ack:
                     ret[vif] = True
-                elif "false" in security_group:
+                elif "false" in security_group_ack:
                     ret[vif] = False
                 else:
-                    LOG.debug("Skipping bad ack value %s" % security_group)
+                    LOG.debug("Skipping bad ack value %s" % security_group_ack)
         return ret
 
     @utils.retry_loop(3)

--- a/quark/tests/cache/test_redis_base.py
+++ b/quark/tests/cache/test_redis_base.py
@@ -55,29 +55,6 @@ class TestClientBase(test_base.TestBase):
         redis_base.ClientBase()
         conn_pool.assert_called_with(host=host, port=port)
         self.assertIsNotNone(redis_base.ClientBase.read_connection_pool)
-        self.assertIsNone(redis_base.ClientBase.write_connection_pool)
-
-    @mock.patch("redis.ConnectionPool")
-    @mock.patch("quark.cache.redis_base.redis.StrictRedis")
-    def test_init_master(self, strict_redis, conn_pool):
-        host = "127.0.0.1"
-        port = 6379
-        redis_base.ClientBase(use_master=True)
-        conn_pool.assert_called_with(host=host, port=port)
-        self.assertIsNone(redis_base.ClientBase.read_connection_pool)
-        self.assertIsNotNone(redis_base.ClientBase.write_connection_pool)
-
-    @mock.patch("redis.ConnectionPool")
-    @mock.patch("quark.cache.redis_base.redis.StrictRedis")
-    def test_init_both(self, strict_redis, conn_pool):
-        host = "127.0.0.1"
-        port = 6379
-        redis_base.ClientBase()
-        redis_base.ClientBase(use_master=True)
-
-        conn_pool.assert_called_with(host=host, port=port)
-
-        self.assertIsNotNone(redis_base.ClientBase.read_connection_pool)
         self.assertIsNotNone(redis_base.ClientBase.write_connection_pool)
 
     @mock.patch("redis.ConnectionPool")

--- a/quark/tests/cache/test_security_groups_client.py
+++ b/quark/tests/cache/test_security_groups_client.py
@@ -310,8 +310,10 @@ class TestRedisForAgent(test_base.TestBase):
             '{"%s": True}' % sg_client.SECURITY_GROUP_ACK,
             '{"%s": "1-2-3"}' % sg_client.SECURITY_GROUP_ACK]
 
-        new_interfaces = ([VIF(1, 2, 9), VIF(3, 4, 0), VIF(5, 6, 1),
-                           VIF(7, 8, 2), VIF(9, 0, 3)])
+        recs = [{"MAC": 2}, {"MAC": 4}, {"MAC": 6}, {"MAC": 8}, {"MAC": 0}]
+        new_interfaces = ([VIF(1, recs[0], 9), VIF(3, recs[1], 0),
+                           VIF(5, recs[2], 1), VIF(7, recs[3], 2),
+                           VIF(9, recs[4], 3)])
 
         group_states = rc.get_security_group_states(new_interfaces)
 
@@ -319,5 +321,6 @@ class TestRedisForAgent(test_base.TestBase):
             ["1.000000000002", "3.000000000004", "5.000000000006",
              "7.000000000008", "9.000000000000"],
             sg_client.SECURITY_GROUP_ACK)
-        self.assertEqual(group_states, {VIF(5, 6, 1): False,
-                                        VIF(7, 8, 2): True})
+
+        self.assertEqual(group_states, {new_interfaces[2]: False,
+                                        new_interfaces[3]: True})


### PR DESCRIPTION
The agent now correctly caches and uses the VIFs the first time it pulls
them from XAPI, rather than fetching them over and over. Additionally
implements handling for ack'ing VIFs only if they actually tagged and
applied their flows.