### PR TITLE
Add ability for admin to allocate mac addresses from do_not_use ranges

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -329,7 +329,8 @@ def mac_address_delete(context, mac_address):
     context.session.delete(mac_address)
 
 
-def mac_address_range_find_allocation_counts(context, address=None):
+def mac_address_range_find_allocation_counts(context, address=None,
+                                             use_forbidden_mac_range=False):
     count = sql_func.count(models.MacAddress.address)
     query = context.session.query(models.MacAddressRange,
                                   count.label("count")).with_lockmode("update")
@@ -340,7 +341,8 @@ def mac_address_range_find_allocation_counts(context, address=None):
         query = query.filter(models.MacAddressRange.last_address >= address)
         query = query.filter(models.MacAddressRange.first_address <= address)
     query = query.filter(models.MacAddressRange.next_auto_assign_mac != -1)
-    query = query.filter(models.MacAddressRange.do_not_use == False)  # noqa
+    if not use_forbidden_mac_range:
+        query = query.filter(models.MacAddressRange.do_not_use == '0')  # noqa
     query = query.limit(1)
     return query.first()
 

--- a/quark/ipam.py
+++ b/quark/ipam.py
@@ -127,12 +127,14 @@ class QuarkIpam(object):
 
     @synchronized(named("allocate_mac_address"))
     def allocate_mac_address(self, context, net_id, port_id, reuse_after,
-                             mac_address=None):
+                             mac_address=None,
+                             use_forbidden_mac_range=False):
         if mac_address:
             mac_address = netaddr.EUI(mac_address).value
 
         kwargs = {"network_id": net_id, "port_id": port_id,
-                  "mac_address": mac_address}
+                  "mac_address": mac_address,
+                  "use_forbidden_mac_range": use_forbidden_mac_range}
         LOG.info(("Attempting to allocate a new MAC address "
                   "[{0}]").format(utils.pretty_kwargs(**kwargs)))
 
@@ -185,7 +187,9 @@ class QuarkIpam(object):
             with context.session.begin():
                 try:
                     fn = db_api.mac_address_range_find_allocation_counts
-                    mac_range = fn(context, address=mac_address)
+                    mac_range = \
+                        fn(context, address=mac_address,
+                           use_forbidden_mac_range=use_forbidden_mac_range)
 
                     if not mac_range:
                         LOG.info("No MAC ranges could be found given "

--- a/quark/plugin_modules/mac_address_ranges.py
+++ b/quark/plugin_modules/mac_address_ranges.py
@@ -91,11 +91,13 @@ def create_mac_address_range(context, mac_range):
         raise exceptions.NotAuthorized()
 
     cidr = mac_range["mac_address_range"]["cidr"]
+    do_not_use = mac_range["mac_address_range"].get("do_not_use", "0")
     cidr, first_address, last_address = _to_mac_range(cidr)
     with context.session.begin():
         new_range = db_api.mac_address_range_create(
             context, cidr=cidr, first_address=first_address,
-            last_address=last_address, next_auto_assign_mac=first_address)
+            last_address=last_address, next_auto_assign_mac=first_address,
+            do_not_use=do_not_use)
     return v._make_mac_range_dict(new_range)
 
 

--- a/quark/tests/functional/db/test_api.py
+++ b/quark/tests/functional/db/test_api.py
@@ -192,3 +192,16 @@ class QuarkFindMacAddressRangeAllocationCount(QuarkIpamBaseFunctionalTest):
                 ranges = db_api.mac_address_range_find_allocation_counts(
                     self.context)
                 self.assertTrue(ranges is None)
+
+    def test_mac_address_ranges_do_not_use_returns_on_use_forbidden_rage(self):
+        mr1_mac = netaddr.EUI("AA:AA:AA:00:00:00")
+        mr1 = {"cidr": "AA:AA:AA/24", "do_not_use": True,
+               "first_address": mr1_mac.value,
+               "last_address": netaddr.EUI("AA:AA:AA:FF:FF:FF").value,
+               "next_auto_assign_mac": mr1_mac.value}
+
+        with self._fixtures([mr1]):
+            with self.context.session.begin():
+                ranges = db_api.mac_address_range_find_allocation_counts(
+                    self.context, use_forbidden_mac_range=True)
+                self.assertTrue(ranges[0]["cidr"], mr1["cidr"])

--- a/quark/tests/plugin_modules/test_ports.py
+++ b/quark/tests/plugin_modules/test_ports.py
@@ -1442,7 +1442,7 @@ class TestQuarkPortCreateFiltering(test_quark_plugin.TestQuarkPlugin):
             alloc_mac.assert_called_once_with(
                 self.context, network["id"], 1,
                 cfg.CONF.QUARK.ipam_reuse_after,
-                mac_address=None)
+                mac_address=None, use_forbidden_mac_range=False)
             port_create.assert_called_once_with(
                 self.context, addresses=[], network_id=network["id"],
                 tenant_id="fake", uuid=1, name="foobar",
@@ -1480,7 +1480,7 @@ class TestQuarkPortCreateFiltering(test_quark_plugin.TestQuarkPlugin):
             alloc_mac.assert_called_once_with(
                 admin_ctx, network["id"], 1,
                 cfg.CONF.QUARK.ipam_reuse_after,
-                mac_address=expected_mac)
+                mac_address=expected_mac, use_forbidden_mac_range=False)
 
             port_create.assert_called_once_with(
                 admin_ctx, bridge=expected_bridge, uuid=1, name="foobar",


### PR DESCRIPTION
This adds ability for admin to allocate
mad address from a do not use range while
creating a port, by passing an arg in
request.