### PR TITLE
Adds support for ICMPv6

### DIFF
--- a/quark/cache/security_groups_client.py
+++ b/quark/cache/security_groups_client.py
@@ -67,7 +67,8 @@ class SecurityGroupsClient(redis_base.ClientBase):
             optional_fields = {}
 
             # NOTE(mdietz): this will expand as we add more protocols
-            if rule["protocol"] == protocols.PROTOCOLS["icmp"]:
+            protocol_map = protocols.PROTOCOL_MAP[rule["ethertype"]]
+            if rule["protocol"] == protocol_map["icmp"]:
                 optional_fields["icmp type"] = rule["port_range_min"]
                 optional_fields["icmp code"] = rule["port_range_max"]
             else:

--- a/quark/plugin_modules/security_groups.py
+++ b/quark/plugin_modules/security_groups.py
@@ -42,10 +42,12 @@ def _validate_security_group_rule(context, rule):
     protocol = rule.pop('protocol')
     port_range_min = rule['port_range_min']
     port_range_max = rule['port_range_max']
+    ethertype = protocols.translate_ethertype(rule["ethertype"])
 
     if protocol:
         protocol = protocols.translate_protocol(protocol, rule["ethertype"])
-        protocols.validate_protocol_with_port_ranges(protocol,
+        protocols.validate_protocol_with_port_ranges(ethertype,
+                                                     protocol,
                                                      port_range_min,
                                                      port_range_max)
         rule['protocol'] = protocol
@@ -53,7 +55,6 @@ def _validate_security_group_rule(context, rule):
         if port_range_min is not None or port_range_max is not None:
             raise sg_ext.SecurityGroupProtocolRequiredWithPorts()
 
-    ethertype = protocols.translate_ethertype(rule["ethertype"])
     rule["ethertype"] = ethertype
 
     protocols.validate_remote_ip_prefix(ethertype,

--- a/quark/protocols.py
+++ b/quark/protocols.py
@@ -31,18 +31,19 @@ ETHERTYPES = {
     "IPv6": 0x86DD
 }
 
-PROTOCOLS = {"icmp": 1, "tcp": 6, "udp": 17}
+PROTOCOLS_V4 = {"icmp": 1, "tcp": 6, "udp": 17}
+PROTOCOLS_V6 = {"tcp": 6, "udp": 17, "icmp": 58}
 
 # Neutron only officially supports TCP, ICMP and UDP,
 # with ethertypes IPv4 and IPv6
 PROTOCOL_MAP = {
-    ETHERTYPES["IPv4"]: PROTOCOLS,
-    ETHERTYPES["IPv6"]: PROTOCOLS
+    ETHERTYPES["IPv4"]: PROTOCOLS_V4,
+    ETHERTYPES["IPv6"]: PROTOCOLS_V6
 }
 
 
 ALLOWED_PROTOCOLS = None
-ALLOWED_WITH_RANGE = [1, 6, 17]
+ALLOWED_WITH_RANGE = [1, 6, 17, 58]
 MIN_PROTOCOL = 0
 MAX_PROTOCOL = 255
 REVERSE_PROTOCOL_MAP = {}
@@ -106,10 +107,10 @@ def validate_remote_ip_prefix(ethertype, prefix):
                               (human_ether, net.version))
 
 
-def validate_protocol_with_port_ranges(protocol, port_range_min,
+def validate_protocol_with_port_ranges(ethertype, protocol, port_range_min,
                                        port_range_max):
     if protocol in ALLOWED_WITH_RANGE:
-        if protocol == PROTOCOLS["icmp"]:
+        if protocol == PROTOCOL_MAP[ethertype]["icmp"]:
             if port_range_min is None and port_range_max is not None:
                 raise sg_ext.SecurityGroupMissingIcmpType()
             elif port_range_min is not None:
@@ -152,8 +153,6 @@ def validate_protocol_with_port_ranges(protocol, port_range_min,
 
 def _init_protocols():
     if not REVERSE_PROTOCOL_MAP:
-        # Protocols don't change between ethertypes, but we want to get
-        # them all, from all ethertypes
         for ether_str, ethertype in ETHERTYPES.iteritems():
             for proto, proto_int in PROTOCOL_MAP[ethertype].iteritems():
                 REVERSE_PROTOCOL_MAP[proto_int] = proto.upper()

--- a/quark/tests/cache/test_security_groups_client.py
+++ b/quark/tests/cache/test_security_groups_client.py
@@ -206,7 +206,7 @@ class TestRedisSecurityGroupsClient(test_base.TestBase):
     @mock.patch(
         "quark.cache.security_groups_client.redis_base.redis.StrictRedis")
     def test_serialize_filters_source_v6_net(self, strict_redis, conn_pool):
-        rule_dict = {"ethertype": 0x86DD, "protocol": 1,
+        rule_dict = {"ethertype": 0x86DD, "protocol": 58,
                      "direction": "ingress",
                      "remote_ip_prefix": "feed::/0"}
         client = sg_client.SecurityGroupsClient()
@@ -218,7 +218,7 @@ class TestRedisSecurityGroupsClient(test_base.TestBase):
         payload = client.serialize_groups([group])
         rule = payload[0]
         self.assertEqual(0x86DD, rule["ethertype"])
-        self.assertEqual(1, rule["protocol"])
+        self.assertEqual(58, rule["protocol"])
         self.assertEqual(None, rule["icmp type"])
         self.assertEqual(None, rule["icmp code"])
         self.assertEqual("allow", rule["action"])
@@ -253,7 +253,7 @@ class TestRedisSecurityGroupsClient(test_base.TestBase):
     @mock.patch(
         "quark.cache.security_groups_client.redis_base.redis.StrictRedis")
     def test_serialize_filters_dest_v6_net(self, strict_redis, conn_pool):
-        rule_dict = {"ethertype": 0x86DD, "protocol": 1,
+        rule_dict = {"ethertype": 0x86DD, "protocol": 58,
                      "direction": "egress",
                      "remote_ip_prefix": "feed::/0"}
         client = sg_client.SecurityGroupsClient()
@@ -265,7 +265,7 @@ class TestRedisSecurityGroupsClient(test_base.TestBase):
         payload = client.serialize_groups([group])
         rule = payload[0]
         self.assertEqual(0x86DD, rule["ethertype"])
-        self.assertEqual(1, rule["protocol"])
+        self.assertEqual(58, rule["protocol"])
         self.assertEqual(None, rule["icmp type"])
         self.assertEqual(None, rule["icmp code"])
         self.assertEqual("allow", rule["action"])


### PR DESCRIPTION
RM11567

Updates the protocol handling code to allow for different sets of
protocol integers between ethertypes. Additionally, adds the correct
protocol number for ICMP under IPv6