### PR TITLE
TOCTOU 2 part 2 the deuce

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -484,9 +484,41 @@ def subnet_find_ordered_by_most_full(context, net_id, **filters):
         query = query.filter(models.Subnet.ip_version == filters["ip_version"])
     if "segment_id" in filters and filters["segment_id"]:
         query = query.filter(models.Subnet.segment_id == filters["segment_id"])
+    query = query.filter(models.Subnet.next_auto_assign_ip != -1)
+
     if "subnet_id" in filters and filters["subnet_id"]:
         query = query.filter(models.Subnet.id.in_(filters["subnet_id"]))
+    return query
+
+
+def subnet_update_next_auto_assign_ip(context, subnet):
+    query = context.session.query(models.Subnet)
+    query = query.filter(models.Subnet.id == subnet["id"])
     query = query.filter(models.Subnet.next_auto_assign_ip != -1)
+
+    # For details on synchronize_session, see:
+    # http://docs.sqlalchemy.org/en/rel_0_8/orm/query.html
+    query = query.update(
+        {"next_auto_assign_ip":
+         models.Subnet.next_auto_assign_ip + 1},
+        synchronize_session=False)
+
+    # Returns a count of the rows matched in the update
+    return query
+
+
+def subnet_update_set_full(context, subnet):
+    query = context.session.query(models.Subnet)
+    query = query.filter_by(id=subnet["id"])
+    query = query.filter(models.Subnet.next_auto_assign_ip != -1)
+
+    # For details on synchronize_session, see:
+    # http://docs.sqlalchemy.org/en/rel_0_8/orm/query.html
+    query = query.update(
+        {"next_auto_assign_ip": -1},
+        synchronize_session=False)
+
+    # Returns a count of the rows matched in the update
     return query
 
 

--- a/quark/db/custom_types.py
+++ b/quark/db/custom_types.py
@@ -34,6 +34,16 @@ class INET(types.TypeDecorator):
             return value
         return long(value)
 
+    def coerce_compared_value(self, op, value):
+        # NOTE(mdietz): If left unimplemented, the column is coerced into a
+        # string every time, causing the next_auto_assign_increment to be a
+        # string concatenation rather than an addition. 'value' in the
+        # signature is the "other" value being compared for the purposes of
+        # casting.
+        if isinstance(value, int):
+            return types.Integer()
+        return self
+
 
 class MACAddress(types.TypeDecorator):
     impl = types.BigInteger


### PR DESCRIPTION
RM10879

Reworks the original patch for RM10879 by completely stripping out
sequential IPv6 address generation, which never made sense anyway.
Instead, when generating a v6, for the edge cases where we would have
generated a sequential address previously, we now use the rfc3041 method
generating a random integer from the port_id within the subnet prefix.
As a result, we also no longer update next_auto_assign_ip on v6 subnets.

Technically this means we no longer need to lock rows when allocation v6
addresses, but I wanted to keep this patch as simple as possible.