### PR TITLE
Enable container-based travis-ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ before_script:
   - "flake8 --show-source --builtins=_ quark"
 script:
   - nosetests --with-coverage --cover-package=quark --cover-erase --cover-html --cover-html-dir=.cover-report --cover-min-percentage=90
+sudo: false


### PR DESCRIPTION
Seeing if http://docs.travis-ci.com/user/workers/container-based-infrastructure/ let's us beat the wait for non-container builds.