### PR TITLE
Wraps delete_vif in exception handling

### DIFF
--- a/quark/drivers/unmanaged.py
+++ b/quark/drivers/unmanaged.py
@@ -82,8 +82,11 @@ class UnmanagedDriver(object):
         # Contacting redis is cheaper than hitting the database to find out
         # if we have rules to delete, and deleting an absence of rules is a
         # NOOP, so this is a safe operation
-        client = sg_client.SecurityGroupsClient(use_master=True)
-        client.delete_vif(kwargs["device_id"], kwargs["mac_address"])
+        try:
+            client = sg_client.SecurityGroupsClient(use_master=True)
+            client.delete_vif(kwargs["device_id"], kwargs["mac_address"])
+        except Exception:
+            LOG.exception("Failed to reach the security groups backend")
 
     def delete_port(self, context, port_id, **kwargs):
         LOG.info("delete_port %s %s" % (context.tenant_id, port_id))


### PR DESCRIPTION
In the event that Redis has gone missing/down, deleting a port would
fail as a result of trying to clean up what may or may not be in Redis.
Continuing in the theme of "It's cheaper to talk to redis than the db"
we simply log any exception from failing to clean up redis and get on
with deleting the port. Meanwhile, the only side-effect of any data
continuing to live in redis is meaningless cruft, and the redis_sg_tool
can find and purge orphaned data later if it's deemed a problem.