### PR TITLE
Added mysql-based functional tests

### DIFF
--- a/quark/tests/functional/mysql/base.py
+++ b/quark/tests/functional/mysql/base.py
@@ -1,0 +1,30 @@
+from neutron import context
+from neutron.db import api as neutron_db_api
+from oslo.config import cfg
+from sqlalchemy.orm import configure_mappers
+
+from quark.db import models
+from quark import quota_driver
+from quark.tests import test_base
+
+
+class MySqlBaseFunctionalTest(test_base.TestBase):
+    @classmethod
+    def setUpClass(cls):
+        cfg.CONF.set_override(
+            'connection',
+            'mysql://root@localhost/quark_functional_tests',
+            'database')
+
+    def setUp(self):
+        super(MySqlBaseFunctionalTest, self).setUp()
+        self.context = context.Context('fake', 'fake', is_admin=False)
+        configure_mappers()
+        engine = neutron_db_api.get_engine()
+        models.BASEV2.metadata.create_all(engine)
+        quota_driver.quota_db.Quota.metadata.create_all(engine)
+
+    def tearDown(self):
+        engine = neutron_db_api.get_engine()
+        models.BASEV2.metadata.drop_all(engine)
+        quota_driver.quota_db.Quota.metadata.drop_all(engine)

--- a/quark/tests/functional/mysql/test_ipam.py
+++ b/quark/tests/functional/mysql/test_ipam.py
@@ -1,0 +1,90 @@
+import contextlib
+import datetime
+
+import mock
+import netaddr
+from neutron.common import exceptions
+from neutron.common import rpc
+from oslo.config import cfg
+from oslo.utils import timeutils
+
+from quark.db import api as db_api
+import quark.ipam
+from quark.tests.functional.mysql.base import MySqlBaseFunctionalTest
+
+
+class QuarkIpamBaseFunctionalTest(MySqlBaseFunctionalTest):
+    def setUp(self):
+        super(QuarkIpamBaseFunctionalTest, self).setUp()
+
+        patcher = mock.patch("neutron.common.rpc.oslo_messaging")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        rpc.init(mock.MagicMock())
+
+
+class QuarkIPAddressReallocate(QuarkIpamBaseFunctionalTest):
+    @contextlib.contextmanager
+    def _stubs(self, network, subnet, address):
+        self.ipam = quark.ipam.QuarkIpamANY()
+        with self.context.session.begin():
+            next_ip = subnet.pop("next_auto_assign_ip", 0)
+            net_mod = db_api.network_create(self.context, **network)
+            subnet["network"] = net_mod
+            sub_mod = db_api.subnet_create(self.context, **subnet)
+
+            address["network_id"] = net_mod["id"]
+            address["subnet_id"] = sub_mod["id"]
+            ip = db_api.ip_address_create(self.context, **address)
+            address.pop("address")
+            db_api.ip_address_update(self.context, ip, **address)
+
+            # NOTE(asadoughi): update after cidr constructor has been invoked
+            db_api.subnet_update(self.context,
+                                 sub_mod,
+                                 next_auto_assign_ip=next_ip)
+        yield net_mod
+
+    def test_allocate_finds_ip_reallocates(self):
+        network = dict(name="public", tenant_id="fake")
+        ipnet = netaddr.IPNetwork("0.0.0.0/24")
+        next_ip = ipnet.ipv6().first + 10
+        subnet = dict(cidr="0.0.0.0/24", next_auto_assign_ip=next_ip,
+                      ip_policy=None, tenant_id="fake", do_not_use=False)
+
+        addr = netaddr.IPAddress("0.0.0.2")
+
+        after_reuse_after = cfg.CONF.QUARK.ipam_reuse_after + 1
+        reusable_after = datetime.timedelta(seconds=after_reuse_after)
+        deallocated_at = timeutils.utcnow() - reusable_after
+        ip_address = dict(address=addr, version=4, _deallocated=True,
+                          deallocated_at=deallocated_at)
+
+        with self._stubs(network, subnet, ip_address) as net:
+            ipaddress = []
+            self.ipam.allocate_ip_address(self.context, ipaddress,
+                                          net["id"], 0, 0)
+            self.assertIsNotNone(ipaddress[0]['id'])
+            expected = netaddr.IPAddress("0.0.0.2").ipv6().value
+            self.assertEqual(ipaddress[0]['address'], expected)
+            self.assertEqual(ipaddress[0]['version'], 4)
+            self.assertEqual(ipaddress[0]['used_by_tenant_id'], "fake")
+
+    def test_allocate_finds_ip_in_do_not_use_subnet_raises(self):
+        network = dict(name="public", tenant_id="fake")
+        ipnet = netaddr.IPNetwork("0.0.0.0/24")
+        next_ip = ipnet.ipv6().first + 3
+        subnet = dict(cidr="0.0.0.0/24", next_auto_assign_ip=next_ip,
+                      ip_policy=None, tenant_id="fake", do_not_use=True)
+
+        addr = netaddr.IPAddress("0.0.0.2")
+        after_reuse_after = cfg.CONF.QUARK.ipam_reuse_after + 1
+        reusable_after = datetime.timedelta(seconds=after_reuse_after)
+        deallocated_at = timeutils.utcnow() - reusable_after
+        ip_address = dict(address=addr, version=4, _deallocated=True,
+                          deallocated_at=deallocated_at)
+
+        with self._stubs(network, subnet, ip_address) as net:
+            with self.assertRaises(exceptions.IpAddressGenerationFailure):
+                self.ipam.allocate_ip_address(self.context, [], net["id"],
+                                              0, 0)

--- a/quark/tests/functional/mysql/test_ports.py
+++ b/quark/tests/functional/mysql/test_ports.py
@@ -1,0 +1,69 @@
+import mock
+import netaddr
+
+import contextlib
+
+from quark import exceptions
+import quark.ipam
+import quark.plugin
+import quark.plugin_modules.mac_address_ranges as macrng_api
+import quark.plugin_modules.networks as network_api
+import quark.plugin_modules.ports as port_api
+import quark.plugin_modules.subnets as subnet_api
+from quark.tests.functional.mysql.base import MySqlBaseFunctionalTest
+
+
+class QuarkUpdatePorts(MySqlBaseFunctionalTest):
+    @contextlib.contextmanager
+    def _stubs(self, network_info, subnet_info, port_info):
+        self.ipam = quark.ipam.QuarkIpamANY()
+        with contextlib.nested(
+                mock.patch("neutron.common.rpc.get_notifier"),
+                mock.patch("neutron.quota.QUOTAS.limit_check")):
+            net = network_api.create_network(self.context, network_info)
+            mac = {'mac_address_range': dict(cidr="AA:BB:CC")}
+            self.context.is_admin = True
+            macrng_api.create_mac_address_range(self.context, mac)
+            self.context.is_admin = False
+            subnet_info['subnet']['network_id'] = net['id']
+            port_info['port']['network_id'] = net['id']
+            sub = subnet_api.create_subnet(self.context, subnet_info)
+            port = port_api.create_port(self.context, port_info)
+            yield net, sub, port
+
+    def test_update_fixed_ips_regression_RM9097(self):
+        cidr = "192.168.1.0/24"
+        ip_network = netaddr.IPNetwork(cidr)
+        network = dict(name="public", tenant_id="fake", network_plugin="BASE")
+        network = {"network": network}
+        subnet = dict(id=1, ip_version=4, next_auto_assign_ip=2,
+                      cidr=cidr, first_ip=ip_network.first,
+                      last_ip=ip_network.last, ip_policy=None,
+                      tenant_id="fake")
+        subnet = {"subnet": subnet}
+        port = {"port": dict()}
+
+        def _make_body(ip):
+            fix_ip = dict(ip_address=ip, subnet_id=sub['id'])
+            port_info = {"port": dict(fixed_ips=[fix_ip])}
+            return port_info
+
+        with self._stubs(network, subnet, port) as (net, sub, port):
+            id = port['id']
+
+            ip = "192.168.1.50"
+            port = port_api.update_port(self.context, id, _make_body(ip))
+            self.assertEqual(ip, port['fixed_ips'][0]['ip_address'])
+
+            with self.assertRaises(exceptions.IPAddressNotInSubnet):
+                ip = "192.168.2.50"
+                port = port_api.update_port(self.context, id, _make_body(ip))
+                self.assertEqual(ip, port['fixed_ips'][0]['ip_address'])
+
+            ip = "192.168.1.75"
+            port = port_api.update_port(self.context, id, _make_body(ip))
+            self.assertEqual(ip, port['fixed_ips'][0]['ip_address'])
+
+            ip = "192.168.1.50"
+            port = port_api.update_port(self.context, id, _make_body(ip))
+            self.assertEqual(ip, port['fixed_ips'][0]['ip_address'])

--- a/quark/tests/functional/test_ipam.py
+++ b/quark/tests/functional/test_ipam.py
@@ -14,14 +14,10 @@
 # limitations under the License.
 
 import contextlib
-import datetime
 
 import mock
 import netaddr
-from neutron.common import exceptions
 from neutron.common import rpc
-from oslo.config import cfg
-from oslo.utils import timeutils
 
 from quark.db import api as db_api
 import quark.ipam
@@ -70,73 +66,6 @@ class QuarkIPAddressAllocate(QuarkIpamBaseFunctionalTest):
             self.assertEqual(ipaddress[0]['address'], 281470681743362)
             self.assertEqual(ipaddress[0]['version'], 4)
             self.assertEqual(ipaddress[0]['used_by_tenant_id'], "fake")
-
-
-class QuarkIPAddressReallocate(QuarkIpamBaseFunctionalTest):
-    @contextlib.contextmanager
-    def _stubs(self, network, subnet, address):
-        self.ipam = quark.ipam.QuarkIpamANY()
-        with self.context.session.begin():
-            next_ip = subnet.pop("next_auto_assign_ip", 0)
-            net_mod = db_api.network_create(self.context, **network)
-            subnet["network"] = net_mod
-            sub_mod = db_api.subnet_create(self.context, **subnet)
-
-            address["network_id"] = net_mod["id"]
-            address["subnet_id"] = sub_mod["id"]
-            ip = db_api.ip_address_create(self.context, **address)
-            address.pop("address")
-            db_api.ip_address_update(self.context, ip, **address)
-
-            # NOTE(asadoughi): update after cidr constructor has been invoked
-            db_api.subnet_update(self.context,
-                                 sub_mod,
-                                 next_auto_assign_ip=next_ip)
-        yield net_mod
-
-    def test_allocate_finds_ip_reallocates(self):
-        network = dict(name="public", tenant_id="fake")
-        ipnet = netaddr.IPNetwork("0.0.0.0/24")
-        next_ip = ipnet.ipv6().first + 10
-        subnet = dict(cidr="0.0.0.0/24", next_auto_assign_ip=next_ip,
-                      ip_policy=None, tenant_id="fake", do_not_use=False)
-
-        addr = netaddr.IPAddress("0.0.0.2")
-
-        after_reuse_after = cfg.CONF.QUARK.ipam_reuse_after + 1
-        reusable_after = datetime.timedelta(seconds=after_reuse_after)
-        deallocated_at = timeutils.utcnow() - reusable_after
-        ip_address = dict(address=addr, version=4, _deallocated=True,
-                          deallocated_at=deallocated_at)
-
-        with self._stubs(network, subnet, ip_address) as net:
-            ipaddress = []
-            self.ipam.allocate_ip_address(self.context, ipaddress,
-                                          net["id"], 0, 0)
-            self.assertIsNotNone(ipaddress[0]['id'])
-            expected = netaddr.IPAddress("0.0.0.2").ipv6().value
-            self.assertEqual(ipaddress[0]['address'], expected)
-            self.assertEqual(ipaddress[0]['version'], 4)
-            self.assertEqual(ipaddress[0]['used_by_tenant_id'], "fake")
-
-    def test_allocate_finds_ip_in_do_not_use_subnet_raises(self):
-        network = dict(name="public", tenant_id="fake")
-        ipnet = netaddr.IPNetwork("0.0.0.0/24")
-        next_ip = ipnet.ipv6().first + 3
-        subnet = dict(cidr="0.0.0.0/24", next_auto_assign_ip=next_ip,
-                      ip_policy=None, tenant_id="fake", do_not_use=True)
-
-        addr = netaddr.IPAddress("0.0.0.2")
-        after_reuse_after = cfg.CONF.QUARK.ipam_reuse_after + 1
-        reusable_after = datetime.timedelta(seconds=after_reuse_after)
-        deallocated_at = timeutils.utcnow() - reusable_after
-        ip_address = dict(address=addr, version=4, _deallocated=True,
-                          deallocated_at=deallocated_at)
-
-        with self._stubs(network, subnet, ip_address) as net:
-            with self.assertRaises(exceptions.IpAddressGenerationFailure):
-                self.ipam.allocate_ip_address(self.context, [], net["id"],
-                                              0, 0)
 
 
 class QuarkIPAddressFindReallocatable(QuarkIpamBaseFunctionalTest):

--- a/quark/tests/functional/test_ports.py
+++ b/quark/tests/functional/test_ports.py
@@ -21,9 +21,6 @@ import contextlib
 from neutron.common import exceptions as q_exc
 
 from quark.db import api as db_api
-from quark import exceptions
-import quark.ipam
-import quark.plugin
 import quark.plugin_modules.mac_address_ranges as macrng_api
 import quark.plugin_modules.networks as network_api
 import quark.plugin_modules.ports as port_api
@@ -296,62 +293,6 @@ class QuarkCreatePortWithForbiddenMacRange(BaseFunctionalTest):
             with self.assertRaises(q_exc.MacAddressGenerationFailure):
                 port_api.create_port(admin_ctxt,
                                      _make_body())
-
-
-class QuarkUpdatePorts(BaseFunctionalTest):
-    @contextlib.contextmanager
-    def _stubs(self, network_info, subnet_info, port_info):
-        self.ipam = quark.ipam.QuarkIpamANY()
-        with contextlib.nested(
-                mock.patch("neutron.common.rpc.get_notifier"),
-                mock.patch("neutron.quota.QUOTAS.limit_check")):
-            net = network_api.create_network(self.context, network_info)
-            mac = {'mac_address_range': dict(cidr="AA:BB:CC")}
-            self.context.is_admin = True
-            macrng_api.create_mac_address_range(self.context, mac)
-            self.context.is_admin = False
-            subnet_info['subnet']['network_id'] = net['id']
-            port_info['port']['network_id'] = net['id']
-            sub = subnet_api.create_subnet(self.context, subnet_info)
-            port = port_api.create_port(self.context, port_info)
-            yield net, sub, port
-
-    def test_update_fixed_ips_regression_RM9097(self):
-        cidr = "192.168.1.0/24"
-        ip_network = netaddr.IPNetwork(cidr)
-        network = dict(name="public", tenant_id="fake", network_plugin="BASE")
-        network = {"network": network}
-        subnet = dict(id=1, ip_version=4, next_auto_assign_ip=2,
-                      cidr=cidr, first_ip=ip_network.first,
-                      last_ip=ip_network.last, ip_policy=None,
-                      tenant_id="fake")
-        subnet = {"subnet": subnet}
-        port = {"port": dict()}
-
-        def _make_body(ip):
-            fix_ip = dict(ip_address=ip, subnet_id=sub['id'])
-            port_info = {"port": dict(fixed_ips=[fix_ip])}
-            return port_info
-
-        with self._stubs(network, subnet, port) as (net, sub, port):
-            id = port['id']
-
-            ip = "192.168.1.50"
-            port = port_api.update_port(self.context, id, _make_body(ip))
-            self.assertEqual(ip, port['fixed_ips'][0]['ip_address'])
-
-            with self.assertRaises(exceptions.IPAddressNotInSubnet):
-                ip = "192.168.2.50"
-                port = port_api.update_port(self.context, id, _make_body(ip))
-                self.assertEqual(ip, port['fixed_ips'][0]['ip_address'])
-
-            ip = "192.168.1.75"
-            port = port_api.update_port(self.context, id, _make_body(ip))
-            self.assertEqual(ip, port['fixed_ips'][0]['ip_address'])
-
-            ip = "192.168.1.50"
-            port = port_api.update_port(self.context, id, _make_body(ip))
-            self.assertEqual(ip, port['fixed_ips'][0]['ip_address'])
 
 
 class QuarkFindPortsFilterByDeviceOwner(BaseFunctionalTest):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,flake8
+envlist = py27,flake8,mysql
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
@@ -12,7 +12,7 @@ setenv = VIRTUAL_ENV={envdir}
          NO_EVENTLET=1
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-commands = nosetests {posargs}
+commands = nosetests --exclude=mysql {posargs}
 
 [tox:jenkins]
 sitepackages = True
@@ -32,7 +32,10 @@ setenv = VIRTUAL_ENV={envdir}
          NOSE_COVER_MIN_PERCENTAGE=90
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-commands = nosetests --cover-package=quark --cover-erase {posargs}
+commands = nosetests --exclude=mysql --cover-package=quark --cover-erase {posargs}
+
+[testenv:mysql]
+commands = nosetests --where=quark/tests/functional/mysql {posargs}
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
Run with `tox -e mysql`. It's configured to connect to
"mysql://root@localhost/neutron".

RM11693