### PR TITLE
Don't lock when selecting v6 subnets

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -597,10 +597,13 @@ def network_delete(context, network):
     context.session.delete(network)
 
 
-def subnet_find_ordered_by_most_full(context, net_id, **filters):
+def subnet_find_ordered_by_most_full(context, net_id, lock_subnets=True,
+                                     **filters):
     count = sql_func.count(models.IPAddress.address).label("count")
     size = (models.Subnet.last_ip - models.Subnet.first_ip)
-    query = context.session.query(models.Subnet, count).with_lockmode('update')
+    query = context.session.query(models.Subnet, count)
+    if lock_subnets:
+        query = query.with_lockmode("update")
     query = query.filter_by(do_not_use=False)
     query = query.outerjoin(models.Subnet.generated_ips)
     query = query.group_by(models.Subnet.id)


### PR DESCRIPTION
NCP-1480

While investigating how to go about incrementing subnets without a lock,
I realized that locking v6 subnets was pointless, as we don't rely on
the next_auto_assign_ip field when generating v6 addresses. While we
don't know what version is available under the ANY IPAM driver, BOTH and
BOTH_REQUIRED explicitly pass versions, allowing us to cut down on the
scenarios where we lock.

This patch is an attempt at a quick-win for mitigating the larger
latency issue, allowing us a bit more time to work on the remaining
tickets.

Please note that the feature itself is toggle-able, to prevent any
fallout if this approach doesn't pan out. It may be enabled by setting
the "ipam_select_subnet_v6_locking" config variable to False under the
[QUARK] config section.