### PR TITLE
Implemented the floating ip update API method

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -299,6 +299,12 @@ def ip_address_delete(context, addr):
     context.session.delete(addr)
 
 
+def ip_address_deallocate(context, address, **kwargs):
+    kwargs["_deallocated"] = 1
+    kwargs["deallocated_at"] = timeutils.utcnow()
+    return ip_address_update(context, address, **kwargs)
+
+
 @scoped
 def ip_address_find(context, lock_mode=False, **filters):
     query = context.session.query(models.IPAddress)
@@ -898,12 +904,11 @@ def floating_ip_find(context, lock_mode=False, limit=None, sorts=None,
                           limit, sorts, marker)
 
 
-def floating_ip_associate_fixed_ip(context, floating_ip, fixed_ip,
-                                   enable=True):
-    assoc = models.FloatingToFixedIPAssociation()
-    assoc.floating_ip_address_id = floating_ip.id
-    assoc.fixed_ip_address_id = fixed_ip.id
-    assoc.enabled = enable
-    context.session.add(assoc)
+def floating_ip_associate_fixed_ip(context, floating_ip, fixed_ip):
     floating_ip.fixed_ip = fixed_ip
+    return floating_ip
+
+
+def floating_ip_disassociate_fixed_ip(context, floating_ip):
+    floating_ip.fixed_ip = None
     return floating_ip

--- a/quark/exceptions.py
+++ b/quark/exceptions.py
@@ -167,3 +167,13 @@ class NoAvailableFixedIPsForPort(exceptions.Conflict):
 
 class PortDoesNotHaveAGateway(exceptions.Conflict):
     message = _("Port %(port_id) does not have a gateway")
+
+
+class PortAlreadyAssociatedToFloatingIP(exceptions.BadRequest):
+    message = _("Port %(port_id) is already associated with "
+                "floating IP %(flip_id)")
+
+
+class FloatingIPUpdateNoPortIdSupplied(exceptions.BadRequest):
+    message = _("When no port is currently associated to the floating if, "
+                "port_id is required but was not supplied")

--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -413,7 +413,8 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
 
     @sessioned
     def update_floatingip(self, context, id, floatingip):
-        return floating_ips.update_floatingip(context, id, floatingip)
+        return floating_ips.update_floatingip(context, id,
+                                              floatingip["floatingip"])
 
     @sessioned
     def get_floatingip(self, context, id, fields=None):

--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -276,13 +276,15 @@ def _make_ip_policy_dict(ipp):
             "exclude": [ippc["cidr"] for ippc in ipp["exclude"]]}
 
 
-def _make_floating_ip_dict(flip):
-    ports = flip.ports
-    port_id = None
-    if ports and len(ports) > 0:
-        port_id = None if not ports[0] else ports[0].id
+def _make_floating_ip_dict(flip, port_id=None):
+    if not port_id:
+        ports = flip.ports
+        port_id = None
+        if ports and len(ports) > 0:
+            port_id = None if not ports[0] else ports[0].id
 
     fixed_ip = flip.fixed_ip
+
     return {"id": flip.get("id"),
             "floating_network_id": flip.get("network_id"),
             "router_id": CONF.QUARK.floating_ip_router_id,


### PR DESCRIPTION
- Implemented the floating IP update logic
- fixed issue with the floating IP create logic where the port was not getting associated with the new floating ip address (in the `quark_port_ip_address_associations` table)
- fixed issue with the floating IP delete logic not cleaning up the port and fixed IP associations

__NOTE:__
The `enable` column of the floating ip to fixed ip assoc table is not used and probably should be removed in a future PR.  This was added under incorrect assumptions/info.  However I did not remove it with the PR as I wanted to have a discussion and its removal is not imperative to the functionality.