### PR TITLE
Shared IPs API

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -85,7 +85,7 @@ def _model_attrs(model):
 def _model_query(context, model, filters, fields=None):
     filters = filters or {}
     model_filters = []
-    eq_filters = ["address", "cidr", "deallocated", "ip_version",
+    eq_filters = ["address", "cidr", "deallocated", "ip_version", "service",
                   "mac_address_range_id", "transaction_id"]
     in_filters = ["device_id", "device_owner", "group_id", "id", "mac_address",
                   "name", "network_id", "segment_id", "subnet_id",
@@ -293,6 +293,10 @@ def ip_address_create(context, **address_dict):
     ip_address["allocated_at"] = timeutils.utcnow()
     context.session.add(ip_address)
     return ip_address
+
+
+def ip_address_delete(context, addr):
+    context.session.delete(addr)
 
 
 @scoped

--- a/quark/db/migration/alembic/versions/4dbf83f37bc0_added_service_column_to_ports_table.py
+++ b/quark/db/migration/alembic/versions/4dbf83f37bc0_added_service_column_to_ports_table.py
@@ -1,0 +1,24 @@
+"""Added service column to port table
+
+Revision ID: 4dbf83f37bc0
+Revises: 33e9e23ba761
+Create Date: 2015-05-26 13:27:38.995202
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4dbf83f37bc0'
+down_revision = '1bdc1b574beb'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('quark_ports', sa.Column('service', sa.String(length=255),
+                                           nullable=False,
+                                           server_default="none"))
+
+
+def downgrade():
+    op.drop_column('quark_ports', 'service')

--- a/quark/db/migration/alembic/versions/HEAD
+++ b/quark/db/migration/alembic/versions/HEAD
@@ -1,1 +1,1 @@
-1bdc1b574beb
+4dbf83f37bc0

--- a/quark/db/models.py
+++ b/quark/db/models.py
@@ -403,6 +403,7 @@ class Port(BASEV2, models.HasTenant, models.HasId):
     device_owner = sa.Column(sa.String(255))
     bridge = sa.Column(sa.String(255))
     associations = orm.relationship(PortIpAssociation, backref="port")
+    service = sa.Column(sa.String(255), default="none")
 
     @declarative.declared_attr
     def ip_addresses(cls):

--- a/quark/exceptions.py
+++ b/quark/exceptions.py
@@ -33,8 +33,12 @@ class AmbigiousLswitchCount(exceptions.NeutronException):
     message = _("Too many lswitches for network %(net_id)s.")
 
 
-class IpAddressNotFound(exceptions.NeutronException):
+class IpAddressNotFound(exceptions.NotFound):
     message = _("IP Address %(addr_id)s not found.")
+
+
+class PortRequiresDisassociation(exceptions.BadRequest):
+    message = _("Port requires disassociation before IP can be deleted")
 
 
 class RouteConflict(exceptions.NeutronException):

--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -244,6 +244,10 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
         return ip_addresses.update_ip_address(context, id, ip_address)
 
     @sessioned
+    def delete_ip_address(self, context, id):
+        return ip_addresses.delete_ip_address(context, id)
+
+    @sessioned
     def create_port(self, context, port):
         self._fix_missing_tenant_id(context, port["port"])
         return ports.create_port(context, port)
@@ -257,10 +261,27 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
         return ports.update_port(context, id, port)
 
     @sessioned
+    def update_port_for_ip(self, context, ip_id, id, port):
+        return ip_addresses.update_port_for_ip_address(context, ip_id, id,
+                                                       port)
+
+    @sessioned
     def get_ports(self, context, limit=None, page_reverse=False, sorts=None,
                   marker=None, filters=None, fields=None):
         return ports.get_ports(context, limit, sorts, marker, page_reverse,
                                filters, fields)
+
+    @sessioned
+    def get_ports_for_ip_address(self, context, ip, limit=None,
+                                 page_reverse=False, sorts=None, marker=None,
+                                 filters=None, fields=None):
+        return ip_addresses.get_ports_for_ip_address(context, ip, limit, sorts,
+                                                     marker, page_reverse,
+                                                     filters, fields)
+
+    @sessioned
+    def get_port_for_ip_address(self, context, ip_id, id, fields=None):
+        return ip_addresses.get_port_for_ip_address(context, ip_id, id, fields)
 
     @sessioned
     def get_ports_count(self, context, filters=None):

--- a/quark/tests/plugin_modules/test_ip_addresses.py
+++ b/quark/tests/plugin_modules/test_ip_addresses.py
@@ -221,8 +221,8 @@ class TestQuarkSharedIPAddressCreate(test_quark_plugin.TestQuarkPlugin):
     def test_create_ip_address_address_type_shared(self, mock_dbapi, mock_ipam,
                                                    *args):
         cfg.CONF.set_override('ipam_reuse_after', 100, "QUARK")
-        ports = [dict(id=1, network_id=2, ip_addresses=[]),
-                 dict(id=2, network_id=2, ip_addresses=[])]
+        ports = [dict(id=1, network_id=2, ip_addresses=[], service="none"),
+                 dict(id=2, network_id=2, ip_addresses=[], service="none")]
         ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
                   subnet_id=1, network_id=2, version=4, used_by_tenant_id=1)
         port_models = [models.Port(**p) for p in ports]
@@ -276,6 +276,38 @@ class TestQuarkSharedIPAddressCreate(test_quark_plugin.TestQuarkPlugin):
             self.context, [ip_model], ip['network_id'], None, 100,
             version=ip_address['version'], ip_addresses=[],
             address_type="fixed")
+
+    def test_fail_to_make_shared_with_active_port(self, mock_dbapi, mock_ipam,
+                                                  *args):
+        cfg.CONF.set_override('ipam_reuse_after', 100, "QUARK")
+        ports = [dict(id=1, network_id=2, ip_addresses=[], service="active"),
+                 dict(id=2, network_id=2, ip_addresses=[], service="none")]
+        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
+                  subnet_id=1, network_id=2, version=4, used_by_tenant_id=1)
+        port_models = [models.Port(**p) for p in ports]
+        ip_model = models.IPAddress()
+        ip_model.update(ip)
+        mock_dbapi.port_find.side_effect = port_models
+        mock_ipam.allocate_ip_address.side_effect = (
+            self._alloc_stub(ip_model))
+
+        ip_address = {"network_id": ip["network_id"],
+                      "version": 4, 'device_ids': [2],
+                      "port_ids": [pm.id for pm in port_models]}
+        qe = quark_exceptions
+        with self.assertRaises(qe.PortRequiresDisassociation):
+            self.plugin.create_ip_address(self.context,
+                                          dict(ip_address=ip_address))
+        # NOTE(thomasem): Having to assert that [ip_model] was passed instead
+        # of an empty list due to the expected behavior of this method being
+        # that it mutates the passed in list. So, after it's run, the list
+        # has already been mutated and it's a reference to that list that
+        # we're checking. This method ought to be changed to return the new
+        # IP and let the caller mutate the list, not the other way around.
+        mock_ipam.allocate_ip_address.assert_called_once_with(
+            self.context, [ip_model], ip['network_id'], None, 100,
+            version=ip_address['version'], ip_addresses=[],
+            address_type="shared")
 
 
 class TestQuarkSharedIPAddressPortsValid(test_quark_plugin.TestQuarkPlugin):
@@ -699,4 +731,236 @@ class TestQuarkGetIpAddresses(test_quark_plugin.TestQuarkPlugin):
                 self.assertEqual(ips[i]["id"], addr["id"])
                 self.assertEqual(ips[i]["subnet_id"], addr["subnet_id"])
                 self.assertEqual(ips[i]["address_readable"], addr["address"])
-                self.assertEqual(addr["port_ids"][0], port["id"])
+
+
+@mock.patch("quark.plugin_modules.ip_addresses"
+            ".validate_ports_on_network_and_same_segment")
+@mock.patch("quark.plugin_modules.ip_addresses.ipam_driver")
+@mock.patch("quark.plugin_modules.ip_addresses.db_api")
+class TestQuarkGetIpAddressPort(test_quark_plugin.TestQuarkPlugin):
+    def _alloc_stub(self, ip_model):
+        def _alloc_ip(context, addr, *args, **kwargs):
+            addr.append(ip_model)
+        return _alloc_ip
+
+    def test_get_ip_address_ports(self, mock_dbapi, mock_ipam, *args):
+        port = dict(mac_address="AA:BB:CC:DD:EE:FF", network_id=1,
+                    tenant_id=self.context.tenant_id, device_id=2,
+                    bridge="xenbr0", device_owner='network:dhcp',
+                    service='none', id=100)
+        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
+                  subnet_id=1, network_id=2, version=4)
+        port_model = models.Port()
+        port_model.update(port)
+        ip_model = models.IPAddress()
+        ip_model.update(ip)
+
+        mock_dbapi.port_find.return_value = [port_model]
+        mock_ipam.allocate_ip_address.side_effect = (
+            self._alloc_stub(ip_model))
+
+        res = self.plugin.get_ports_for_ip_address(self.context, 1)[0]
+        self.assertEqual(port["id"], res["id"])
+        self.assertEqual(port["service"], res["service"])
+        self.assertEqual(port["device_id"], res["device_id"])
+        self.assertFalse('mac_address' in res)
+        self.assertFalse('network_id' in res)
+        self.assertFalse('bridge' in res)
+        self.assertFalse('tenant_id' in res)
+
+    def test_get_ip_address_port(self, mock_dbapi, mock_ipam, *args):
+        port = dict(mac_address="AA:BB:CC:DD:EE:FF", network_id=1,
+                    tenant_id=self.context.tenant_id, device_id=2,
+                    bridge="xenbr0", device_owner='network:dhcp',
+                    service='none', id=100)
+        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
+                  subnet_id=1, network_id=2, version=4)
+        port_model = models.Port()
+        port_model.update(port)
+        ip_model = models.IPAddress()
+        ip_model.update(ip)
+
+        mock_dbapi.port_find.return_value = port_model
+        mock_ipam.allocate_ip_address.side_effect = (
+            self._alloc_stub(ip_model))
+
+        res = self.plugin.get_port_for_ip_address(self.context, 1, 100)
+        self.assertEqual(port["id"], res["id"])
+        self.assertEqual(port["service"], res["service"])
+        self.assertEqual(port["device_id"], res["device_id"])
+        self.assertFalse('mac_address' in res)
+        self.assertFalse('network_id' in res)
+        self.assertFalse('bridge' in res)
+        self.assertFalse('tenant_id' in res)
+
+    def test_deleting_inactive_shared_ip(self, mock_dbapi, mock_ipam, *args):
+        port = dict(id=100, service='none', network_id=2,
+                    backend_key="derp", device_id="y")
+        port2 = dict(id=101, service='none', network_id=2,
+                     backend_key="derp", device_id="x")
+        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
+                  subnet_id=1, network_id=2, version=4, address_type="shared")
+        port_model = models.Port()
+        port_model2 = models.Port()
+        port_model.update(port)
+        port_model2.update(port2)
+        ip_model = models.IPAddress()
+        ip_model.update(ip)
+        ip_model.ports = [port_model, port_model2]
+
+        mock_dbapi.port_find.return_value = port_model
+        mock_dbapi.ip_address_find.return_value = ip_model
+        mock_ipam.allocate_ip_address.side_effect = (
+            self._alloc_stub(ip_model))
+        self.plugin.delete_ip_address(self.context, 1)
+        self.assertFalse(mock_dbapi.ip_address_delete.called)
+        self.assertTrue(mock_ipam.deallocate_ip_address.called)
+
+    def test_get_ip_address_no_ip_fails(self, mock_dbapi, mock_ipam, *args):
+        mock_dbapi.ip_address_find.return_value = []
+        with self.assertRaises(quark_exceptions.IpAddressNotFound):
+            self.plugin.get_port_for_ip_address(self.context, 123, 100)
+
+    def test_get_ip_address_no_port_fails(self, mock_dbapi, mock_ipam, *args):
+        mock_dbapi.port_find.return_value = []
+        with self.assertRaises(exceptions.PortNotFound):
+            self.plugin.get_port_for_ip_address(self.context, 123, 100)
+
+    def test_bad_request_when_deleting_active_shared_ip(self, mock_dbapi,
+                                                        mock_ipam, *args):
+        port = dict(id=100, service='considered_active', network_id=2,
+                    backend_key="derp", device_id="y")
+        port2 = dict(id=101, service='considered_active', network_id=2,
+                     backend_key="derp", device_id="x")
+        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
+                  subnet_id=1, network_id=2, version=4, address_type="shared")
+        port_model = models.Port()
+        port_model2 = models.Port()
+        port_model.update(port)
+        port_model2.update(port2)
+        ip_model = models.IPAddress()
+        ip_model.update(ip)
+        ip_model.ports = [port_model, port_model2]
+
+        mock_dbapi.port_find.return_value = port_model
+        mock_dbapi.ip_address_find.return_value = ip_model
+        mock_ipam.allocate_ip_address.side_effect = (
+            self._alloc_stub(ip_model))
+        qe = quark_exceptions
+        with self.assertRaises(qe.PortRequiresDisassociation):
+            self.plugin.delete_ip_address(self.context, 1)
+
+    def test_bad_request_deleting_single_active_shared_ip(self, mock_dbapi,
+                                                          mock_ipam, *args):
+        port = dict(id=100, service='none', network_id=2,
+                    backend_key="derp", device_id="y")
+        port2 = dict(id=101, service='considered_active', network_id=2,
+                     backend_key="derp", device_id="x")
+        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
+                  subnet_id=1, network_id=2, version=4, address_type="shared")
+        port_model = models.Port()
+        port_model2 = models.Port()
+        port_model.update(port)
+        port_model2.update(port2)
+        ip_model = models.IPAddress()
+        ip_model.update(ip)
+        ip_model.ports = [port_model, port_model2]
+
+        mock_dbapi.port_find.return_value = port_model
+        mock_dbapi.ip_address_find.return_value = ip_model
+        mock_ipam.allocate_ip_address.side_effect = (
+            self._alloc_stub(ip_model))
+        qe = quark_exceptions
+        with self.assertRaises(qe.PortRequiresDisassociation):
+            self.plugin.delete_ip_address(self.context, 1)
+
+    def test_update_port_service_inactive_ip(self, mock_dbapi, mock_ipam,
+                                             *args):
+        port = dict(id=100, service='none', network_id=2,
+                    backend_key="derp", device_id="y")
+        port2 = dict(id=101, service='none', network_id=2,
+                     backend_key="derp", device_id="x")
+        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
+                  subnet_id=1, network_id=2, version=4, address_type="shared")
+        port_model = models.Port()
+        port_model2 = models.Port()
+        port_model.update(port)
+        port_model2.update(port2)
+        ip_model = models.IPAddress()
+        ip_model.update(ip)
+        ip_model.ports = [port_model, port_model2]
+
+        mock_port_update = patch('quark.plugin_modules.ports.update_port')
+        self.addCleanup(mock_port_update.stop)
+        mock_port_update = mock_port_update.start()
+
+        mock_dbapi.port_find.return_value = port_model
+        mock_dbapi.ip_address_find.return_value = ip_model
+        mock_ipam.allocate_ip_address.side_effect = (
+            self._alloc_stub(ip_model))
+        port_update = dict(service='derp')
+        port_update = {'port': port_update}
+        self.plugin.update_port_for_ip(self.context, 1, 100, port_update)
+        self.assertTrue(mock_port_update.called)
+        self.assertTrue(mock_port_update.called_once_with(
+            self.context, 100, port_update))
+
+    def test_fail_to_update_service_with_active_shared_ip(self, mock_dbapi,
+                                                          mock_ipam, *args):
+        port = dict(id=100, service='none', network_id=2,
+                    backend_key="derp", device_id="y")
+        port2 = dict(id=101, service='compute', network_id=2,
+                     backend_key="derp", device_id="x")
+        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
+                  subnet_id=1, network_id=2, version=4, address_type="shared")
+        port_model = models.Port()
+        port_model2 = models.Port()
+        port_model.update(port)
+        port_model2.update(port2)
+        ip_model = models.IPAddress()
+        ip_model.update(ip)
+        ip_model.ports = [port_model, port_model2]
+
+        mock_port_update = patch('quark.plugin_modules.ports.update_port')
+        self.addCleanup(mock_port_update.stop)
+        mock_port_update = mock_port_update.start()
+
+        mock_dbapi.port_find.return_value = port_model
+        mock_dbapi.ip_address_find.return_value = ip_model
+        mock_ipam.allocate_ip_address.side_effect = (
+            self._alloc_stub(ip_model))
+        port_update = dict(service='derp')
+        port_update = {'port': port_update}
+        qe = quark_exceptions
+        with self.assertRaises(qe.PortRequiresDisassociation):
+            self.plugin.update_port_for_ip(self.context, 1, 100, port_update)
+
+    def test_update_shared_ip_deactivate(self, mock_dbapi, mock_ipam, *args):
+        port = dict(id=100, service='compute', network_id=2,
+                    backend_key="derp", device_id="y")
+        port2 = dict(id=101, service='none', network_id=2,
+                     backend_key="derp", device_id="x")
+        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
+                  subnet_id=1, network_id=2, version=4, address_type="shared")
+        port_model = models.Port()
+        port_model2 = models.Port()
+        port_model.update(port)
+        port_model2.update(port2)
+        ip_model = models.IPAddress()
+        ip_model.update(ip)
+        ip_model.ports = [port_model, port_model2]
+
+        mock_port_update = patch('quark.plugin_modules.ports.update_port')
+        self.addCleanup(mock_port_update.stop)
+        mock_port_update = mock_port_update.start()
+
+        mock_dbapi.port_find.return_value = port_model
+        mock_dbapi.ip_address_find.return_value = ip_model
+        mock_ipam.allocate_ip_address.side_effect = (
+            self._alloc_stub(ip_model))
+        port_update = dict(service='derp')
+        port_update = {'port': port_update}
+        self.plugin.update_port_for_ip(self.context, 1, 100, port_update)
+        self.assertTrue(mock_port_update.called)
+        self.assertTrue(mock_port_update.called_once_with(
+            self.context, 100, port_update))


### PR DESCRIPTION
Adds support for a new sub resources:

  * /ip_addresses/<id>/ports
  * /ip_addresses/<id>/ports/<id>

While these new resources are essentially the same construct as /ports they
have their own view and thus produce different output.

Current version does not include the code for quotas and policy.