### PR TITLE
Fixes API design bug

### DIFF
--- a/docs/shared_ips.raml
+++ b/docs/shared_ips.raml
@@ -217,7 +217,6 @@ traits:
                         400:
                             description: |
                                 bad input
-                                * where another port for this given IP is active
                                 * service string too long (max 256, for example)
                         401:
                             description: |


### PR DESCRIPTION
Allow multiple servers to associate with the same IP.

Multiple servers will associate with the same IP, but which server
actually uses the IP is determined by the application layer, using
VRRP and GARP, and not the control plane.

JIRA:NCP-1558