### PR TITLE
Delay aiclib package updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ oslo.middleware
 zope.sqlalchemy
 mysql-python
 http://tarballs.openstack.org/neutron/neutron-master.tar.gz#egg=neutron
-aiclib
+aiclib==0.84
 gunicorn
 pymysql>=0.6.2
 redis==2.10.3


### PR DESCRIPTION
Want to test other changes before we pull in the new aiclib stuff.
When we're ready to test it, remove the ==0.84 and create a package.

JIRA:NCP-1188