### PR TITLE
Fix for upstream change

### DIFF
--- a/quark/db/migration/alembic/__init__.py
+++ b/quark/db/migration/alembic/__init__.py
@@ -8,6 +8,6 @@ from quark import quota_driver
 target_metadata = models.BASEV2.metadata
 # FIXME: https://bitbucket.org/zzzeek/alembic/issue/38
 table_names = set([tbl.name for tbl in target_metadata.sorted_tables])
-for t in quota_driver.quota_db.Quota.metadata.tables.values():
+for t in quota_driver.Quota.metadata.tables.values():
     if t.name == "quotas" and t.name not in table_names:
         t.tometadata(target_metadata)

--- a/quark/plugin_modules/networks.py
+++ b/quark/plugin_modules/networks.py
@@ -15,7 +15,6 @@
 
 import netaddr
 from neutron.common import exceptions
-from neutron.db import quota_db as qdb
 from neutron.extensions import providernet as pnet
 from neutron import quota
 from oslo_config import cfg
@@ -31,6 +30,7 @@ from quark import network_strategy
 from quark.plugin_modules import ports
 from quark.plugin_modules import subnets
 from quark import plugin_views as v
+from quark import quota_driver as qdv
 from quark import utils
 
 CONF = cfg.CONF
@@ -76,7 +76,7 @@ def create_network(context, network):
                     else:
                         v4_count += 1
                 if v4_count > 0:
-                    tenant_q_v4 = context.session.query(qdb.Quota).filter_by(
+                    tenant_q_v4 = context.session.query(qdv.Quota).filter_by(
                         tenant_id=context.tenant_id,
                         resource='v4_subnets_per_network').first()
                     if tenant_q_v4 != -1:
@@ -85,7 +85,7 @@ def create_network(context, network):
                             context.tenant_id,
                             v4_subnets_per_network=v4_count)
                 if v6_count > 0:
-                    tenant_q_v6 = context.session.query(qdb.Quota).filter_by(
+                    tenant_q_v6 = context.session.query(qdv.Quota).filter_by(
                         tenant_id=context.tenant_id,
                         resource='v6_subnets_per_network').first()
                     if tenant_q_v6 != -1:

--- a/quark/plugin_modules/subnets.py
+++ b/quark/plugin_modules/subnets.py
@@ -17,7 +17,6 @@ import netaddr
 from neutron.common import config as neutron_cfg
 from neutron.common import exceptions
 from neutron.common import rpc as n_rpc
-from neutron.db import quota_db as qdb
 from neutron import quota
 from oslo_config import cfg
 from oslo_log import log as logging
@@ -32,6 +31,7 @@ from quark import network_strategy
 from quark.plugin_modules import ip_policies
 from quark.plugin_modules import routes
 from quark import plugin_views as v
+from quark import quota_driver as qdv
 from quark import utils
 
 CONF = cfg.CONF
@@ -140,7 +140,7 @@ def create_subnet(context, subnet):
                     v4_count += 1
 
             if cidr.version == 6:
-                tenant_quota_v6 = context.session.query(qdb.Quota).filter_by(
+                tenant_quota_v6 = context.session.query(qdv.Quota).filter_by(
                     tenant_id=context.tenant_id,
                     resource='v6_subnets_per_network').first()
                 if tenant_quota_v6 != -1:
@@ -148,7 +148,7 @@ def create_subnet(context, subnet):
                         context, context.tenant_id,
                         v6_subnets_per_network=v6_count + 1)
             else:
-                tenant_quota_v4 = context.session.query(qdb.Quota).filter_by(
+                tenant_quota_v4 = context.session.query(qdv.Quota).filter_by(
                     tenant_id=context.tenant_id,
                     resource='v4_subnets_per_network').first()
                 if tenant_quota_v4 != -1:

--- a/quark/quota_driver.py
+++ b/quark/quota_driver.py
@@ -15,6 +15,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from neutron.db.quota.models import Quota
 from neutron.db import quota_db
 
 
@@ -31,19 +32,19 @@ class QuarkQuotaDriver(quota_db.DbQuotaDriver):
         Atfer deletion, this tenant will use default quota values in conf.
         """
 
-        tenant_quotas = context.session.query(quota_db.Quota)
+        tenant_quotas = context.session.query(Quota)
         tenant_quotas = tenant_quotas.filter_by(tenant_id=tenant_id)
         tenant_quotas.delete()
 
     @staticmethod
     def update_quota_limit(context, tenant_id, resource, limit):
-        tenant_quota = context.session.query(quota_db.Quota).filter_by(
+        tenant_quota = context.session.query(Quota).filter_by(
             tenant_id=tenant_id, resource=resource).first()
 
         if tenant_quota:
             tenant_quota.update({'limit': limit})
         else:
-            tenant_quota = quota_db.Quota(tenant_id=tenant_id,
-                                          resource=resource,
-                                          limit=limit)
+            tenant_quota = Quota(tenant_id=tenant_id,
+                                 resource=resource,
+                                 limit=limit)
             context.session.add(tenant_quota)

--- a/quark/tests/functional/base.py
+++ b/quark/tests/functional/base.py
@@ -19,10 +19,10 @@ class BaseFunctionalTest(test_base.TestBase):
         neutron_db_api._FACADE = None
         self.engine = neutron_db_api.get_engine()
         models.BASEV2.metadata.create_all(self.engine)
-        quota_driver.quota_db.Quota.metadata.create_all(self.engine)
+        quota_driver.Quota.metadata.create_all(self.engine)
 
     def tearDown(self):
         self.context = None
         neutron_db_api._FACADE = None
         models.BASEV2.metadata.drop_all(self.engine)
-        quota_driver.quota_db.Quota.metadata.drop_all(self.engine)
+        quota_driver.Quota.metadata.drop_all(self.engine)

--- a/quark/tests/functional/mysql/base.py
+++ b/quark/tests/functional/mysql/base.py
@@ -30,9 +30,9 @@ class MySqlBaseFunctionalTest(test_base.TestBase):
         configure_mappers()
         engine = neutron_db_api.get_engine()
         models.BASEV2.metadata.create_all(engine)
-        quota_driver.quota_db.Quota.metadata.create_all(engine)
+        quota_driver.Quota.metadata.create_all(engine)
 
     def tearDown(self):
         engine = neutron_db_api.get_engine()
         models.BASEV2.metadata.drop_all(engine)
-        quota_driver.quota_db.Quota.metadata.drop_all(engine)
+        quota_driver.Quota.metadata.drop_all(engine)


### PR DESCRIPTION
Quota class was moved in upstream neutron commit:
b3d4851f6370d9892a189c35d14b22dcbeb58200

Inside quark, moved the Quota import to the quota_driver class as
a single reference point so if upstream changes the location again
later we only have to update one place.