### PR TITLE
Allow None to be passed in as a filter-value

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -115,9 +115,6 @@ def _model_query(context, model, filters, fields=None):
         eq_filters.extend(sg_rule_attribs)
 
     for key, value in filters.items():
-        # This is mostly for unittests, as they're configured to send in None
-        if value is None:
-            continue
         if key in in_filters:
             model_type = getattr(model, key)
             model_filters.append(model_type.in_(value))

--- a/quark/ipam.py
+++ b/quark/ipam.py
@@ -222,10 +222,12 @@ class QuarkIpam(object):
                     "transaction_id": transaction.id
                 }
                 filter_kwargs = {
-                    "reuse_after": reuse_after,
                     "deallocated": True,
-                    "address": mac_address
                 }
+                if mac_address is not None:
+                    filter_kwargs["address"] = mac_address
+                if reuse_after is not None:
+                    filter_kwargs["reuse_after"] = reuse_after
                 elevated = context.elevated()
                 result = db_api.mac_address_reallocate(
                     elevated, update_kwargs, **filter_kwargs)
@@ -363,12 +365,13 @@ class QuarkIpam(object):
 
         ip_kwargs = {
             "network_id": net_id,
-            "reuse_after": reuse_after,
             "deallocated": True,
-            "ip_address": ip_address,
             "version": version,
         }
-        if ip_address:
+        if reuse_after is not None:
+            ip_kwargs["reuse_after"] = reuse_after
+        if ip_address is not None:
+            ip_kwargs["ip_address"] = ip_address
             del ip_kwargs["deallocated"]
         if sub_ids:
             ip_kwargs["subnet_id"] = sub_ids

--- a/quark/tests/functional/mysql/test_db_ip_reallocate.py
+++ b/quark/tests/functional/mysql/test_db_ip_reallocate.py
@@ -82,9 +82,7 @@ class QuarkIPReallocateFunctionalTest(MySqlBaseFunctionalTest,
             "network_id": self.network_db["id"],
             "reuse_after": self.REUSE_AFTER,
             "deallocated": True,
-            "ip_address": None,
             "version": 4,
-            "subnet_id": None
         }
         reallocated = db_api.ip_address_reallocate(
             self.context,
@@ -97,9 +95,7 @@ class QuarkIPReallocateFunctionalTest(MySqlBaseFunctionalTest,
             "network_id": self.network_db["id"],
             "reuse_after": self.REUSE_AFTER,
             "deallocated": True,
-            "ip_address": None,
             "version": 6,
-            "subnet_id": None
         }
         reallocated = db_api.ip_address_reallocate(
             self.context,
@@ -111,10 +107,8 @@ class QuarkIPReallocateFunctionalTest(MySqlBaseFunctionalTest,
         ip_kwargs = {
             "network_id": self.network_db["id"],
             "reuse_after": self.REUSE_AFTER,
-            "deallocated": None,
             "ip_address": self.ip_address_v4,
             "version": 4,
-            "subnet_id": None
         }
         reallocated = db_api.ip_address_reallocate(
             self.context,
@@ -127,7 +121,6 @@ class QuarkIPReallocateFunctionalTest(MySqlBaseFunctionalTest,
             "network_id": self.network_db["id"],
             "reuse_after": self.REUSE_AFTER,
             "deallocated": True,
-            "ip_address": None,
             "version": 4,
             "subnet_id": [self.subnet_v4_db["id"]]
         }
@@ -142,9 +135,7 @@ class QuarkIPReallocateFunctionalTest(MySqlBaseFunctionalTest,
             "network_id": self.network_db["id"],
             "reuse_after": self.REUSE_AFTER * 2,
             "deallocated": True,
-            "ip_address": None,
             "version": 4,
-            "subnet_id": None
         }
         reallocated = db_api.ip_address_reallocate(
             self.context,
@@ -157,9 +148,6 @@ class QuarkIPReallocateFunctionalTest(MySqlBaseFunctionalTest,
             "network_id": self.network_db["id"],
             "reuse_after": self.REUSE_AFTER,
             "deallocated": True,
-            "ip_address": None,
-            "version": None,
-            "subnet_id": None
         }
         reallocated = db_api.ip_address_reallocate(
             self.context,
@@ -175,9 +163,7 @@ class QuarkIPReallocateFindTest(MySqlBaseFunctionalTest, IPReallocateMixin):
             "network_id": self.network_db["id"],
             "reuse_after": self.REUSE_AFTER,
             "deallocated": True,
-            "ip_address": None,
             "version": 4,
-            "subnet_id": None
         }
         reallocated = db_api.ip_address_reallocate(
             self.context,
@@ -196,9 +182,7 @@ class QuarkIPReallocateFindTest(MySqlBaseFunctionalTest, IPReallocateMixin):
             "network_id": self.network_db["id"],
             "reuse_after": self.REUSE_AFTER,
             "deallocated": True,
-            "ip_address": None,
             "version": 6,
-            "subnet_id": None
         }
         reallocated = db_api.ip_address_reallocate(
             self.context,
@@ -229,9 +213,7 @@ class QuarkIPReallocateFindTest(MySqlBaseFunctionalTest, IPReallocateMixin):
             "network_id": self.network_db["id"],
             "reuse_after": self.REUSE_AFTER,
             "deallocated": True,
-            "ip_address": None,
             "version": 4,
-            "subnet_id": None
         }
         reallocated = db_api.ip_address_reallocate(
             self.context,
@@ -255,9 +237,7 @@ class QuarkIPReallocateFindTest(MySqlBaseFunctionalTest, IPReallocateMixin):
             "network_id": self.network_db["id"],
             "reuse_after": self.REUSE_AFTER,
             "deallocated": True,
-            "ip_address": None,
             "version": 4,
-            "subnet_id": None
         }
         reallocated = db_api.ip_address_reallocate(
             self.context,
@@ -282,9 +262,7 @@ class QuarkIPReallocateFindTest(MySqlBaseFunctionalTest, IPReallocateMixin):
             "network_id": self.network_db["id"],
             "reuse_after": self.REUSE_AFTER,
             "deallocated": True,
-            "ip_address": None,
             "version": 4,
-            "subnet_id": None
         }
         reallocated = db_api.ip_address_reallocate(
             self.context,
@@ -315,9 +293,7 @@ class QuarkIPReallocateFindTest(MySqlBaseFunctionalTest, IPReallocateMixin):
             "network_id": self.network_db["id"],
             "reuse_after": self.REUSE_AFTER,
             "deallocated": True,
-            "ip_address": None,
             "version": 4,
-            "subnet_id": None
         }
         reallocated = db_api.ip_address_reallocate(
             self.context,


### PR DESCRIPTION
Enables finding ip_addresses without locks (lock_id = null).

JIRA:NCP-1622