### PR TITLE
All the fixes from 180 pushed to master

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -263,8 +263,15 @@ def port_associate_ip(context, ports, address, enable_port=None):
     return address
 
 
+def get_ports_for_address(address):
+    ports = []
+    for assoc in address.associations:
+        ports.append(assoc.port)
+    return ports
+
+
 def update_port_associations_for_ip(context, ports, address):
-    assoc_ports = set(address.ports)
+    assoc_ports = set(get_ports_for_address(address))
     new_ports = set(ports)
     new_address = port_associate_ip(context, new_ports - assoc_ports,
                                     address)
@@ -546,8 +553,11 @@ def network_find(context, limit=None, sorts=None, marker=None,
                  page_reverse=False, fields=None, **filters):
     ids = []
     defaults = []
+    provider_query = False
     if "id" in filters:
         ids, defaults = STRATEGY.split_network_ids(context, filters["id"])
+        if not ids and defaults and "shared" not in filters:
+            provider_query = True
         if ids:
             filters["id"] = ids
         else:
@@ -565,11 +575,12 @@ def network_find(context, limit=None, sorts=None, marker=None,
             defaults.insert(0, INVERT_DEFAULTS)
         filters.pop("shared")
     return _network_find(context, limit, sorts, marker, page_reverse, fields,
-                         defaults=defaults, **filters)
+                         defaults=defaults, provider_query=provider_query,
+                         **filters)
 
 
 def _network_find(context, limit, sorts, marker, page_reverse, fields,
-                  defaults=None, **filters):
+                  defaults=None, provider_query=False, **filters):
     query = context.session.query(models.Network)
     model_filters = _model_query(context, models.Network, filters, query)
 
@@ -581,7 +592,7 @@ def _network_find(context, limit, sorts, marker, page_reverse, fields,
         if filters and invert_defaults:
             query = query.filter(and_(not_(models.Network.id.in_(defaults)),
                                       and_(*model_filters)))
-        elif filters and not invert_defaults:
+        elif not provider_query and filters and not invert_defaults:
             query = query.filter(or_(models.Network.id.in_(defaults),
                                      and_(*model_filters)))
 

--- a/quark/db/models.py
+++ b/quark/db/models.py
@@ -175,17 +175,11 @@ class IPAddress(BASEV2, models.HasId):
     def is_shared(self):
         return self.address_type == ip_types.SHARED
 
-    def has_shared_owner(self):
+    def has_any_shared_owner(self):
         for assoc in self["associations"]:
             if assoc.service != 'none' and assoc.service is not None:
                 return True
         return False
-
-    def get_shared_owner(self):
-        for assoc in self["associations"]:
-            if assoc.service != 'none' and assoc.service is not None:
-                return assoc.port
-        return None
 
     def set_service_for_port(self, port, service):
         for assoc in self["associations"]:

--- a/quark/exceptions.py
+++ b/quark/exceptions.py
@@ -177,3 +177,19 @@ class PortAlreadyAssociatedToFloatingIP(exceptions.BadRequest):
 class FloatingIPUpdateNoPortIdSupplied(exceptions.BadRequest):
     message = _("When no port is currently associated to the floating if, "
                 "port_id is required but was not supplied")
+
+
+class PortOrDeviceNotFound(exceptions.PortNotFound):
+    message = _("Suitable port or device could not be found")
+
+
+class NotAllPortOrDeviceFound(exceptions.NotFound):
+    message = _("Not all ports or devices from request could be found")
+
+
+class CannotAddMoreIPsToPort(exceptions.OverQuota):
+    message = _("Cannot add more IPs to port")
+
+
+class CannotCreateMoreSharedIPs(exceptions.OverQuota):
+    message = _("Cannot create more shared IPs on selected network")

--- a/quark/ipam.py
+++ b/quark/ipam.py
@@ -608,7 +608,7 @@ class QuarkIpam(object):
 
         def _try_reallocate_ip_address(ipam_log, ip_addr=None):
             new_addresses.extend(self.attempt_to_reallocate_ip(
-                context, net_id, port_id, reuse_after, version=None,
+                context, net_id, port_id, reuse_after, version=version,
                 ip_address=ip_addr, segment_id=segment_id, subnets=subnets,
                 **kwargs))
 

--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -88,8 +88,8 @@ quark_quota_opts = [
                default=1,
                help=_('Maximum v6 subnets per network')),
     cfg.IntOpt('quota_fixed_ips_per_port',
-               default=5,
-               help=_('Maximum number of fixed IPs per port'))
+               default=6,
+               help=_('Maximum number of fixed IPs per port')),
 ]
 
 

--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -42,10 +42,6 @@ quark_view_opts = [
                 default=True,
                 help=_('Controls whether or not to show ip_policy_id for'
                        'subnets')),
-    cfg.BoolOpt('show_port_service',
-                default=False,
-                help=_('Controls whether or not to show service for'
-                       'ports'))
 ]
 
 CONF.register_opts(quark_view_opts, "QUARK")
@@ -175,9 +171,6 @@ def _port_dict(port, fields=None):
                                port.get("security_groups", None)],
            "device_id": port.get("device_id"),
            "device_owner": port.get("device_owner")}
-
-    if CONF.QUARK.show_port_service:
-        res['service'] = port.get("service")
 
     if "mac_address" in res and res["mac_address"]:
         mac = str(netaddr.EUI(res["mac_address"])).replace('-', ':')

--- a/quark/tests/functional/mysql/test_ip_addresses.py
+++ b/quark/tests/functional/mysql/test_ip_addresses.py
@@ -3,7 +3,6 @@ import netaddr
 
 import contextlib
 
-from oslo_config import cfg
 from quark.db import api as db_api
 from quark.db import ip_types
 import quark.ipam
@@ -37,13 +36,9 @@ class QuarkSharedIPs(MySqlBaseFunctionalTest):
 
     def setUp(self):
         super(QuarkSharedIPs, self).setUp()
-        self.old_show_port_service = cfg.CONF.QUARK.show_port_service
-        cfg.CONF.set_override('show_port_service', True, 'QUARK')
 
     def tearDown(self):
         super(QuarkSharedIPs, self).tearDown()
-        cfg.CONF.set_override('show_port_service', self.old_show_port_service,
-                              'QUARK')
 
     @contextlib.contextmanager
     def _stubs(self, network_info, subnet_info, ports_info):

--- a/quark/tests/plugin_modules/test_ip_addresses.py
+++ b/quark/tests/plugin_modules/test_ip_addresses.py
@@ -21,6 +21,7 @@ from neutron.common import exceptions
 from oslo_config import cfg
 import webob
 
+from quark.db import ip_types
 from quark.db import models
 from quark import exceptions as quark_exceptions
 from quark.plugin_modules import ip_addresses
@@ -86,6 +87,8 @@ class TestIpAddresses(test_quark_plugin.TestQuarkPlugin):
             yield
 
     def test_create_ip_address_by_network_and_device(self):
+        old_cfg = cfg.CONF.QUARK.ipaddr_allow_fixed_ip
+        cfg.CONF.set_override('ipaddr_allow_fixed_ip', True, "QUARK")
         port = dict(id=1, network_id=2, ip_addresses=[])
         ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
                   subnet_id=1, network_id=2, version=4, used_by_tenant_id=1)
@@ -102,8 +105,11 @@ class TestIpAddresses(test_quark_plugin.TestQuarkPlugin):
             self.assertEqual(response["version"], 4)
             self.assertEqual(response["address"], "192.168.1.100")
             self.assertEqual(response["tenant_id"], 1)
+        cfg.CONF.set_override('ipaddr_allow_fixed_ip', old_cfg, "QUARK")
 
     def test_create_ip_address_with_port(self):
+        old_cfg = cfg.CONF.QUARK.ipaddr_allow_fixed_ip
+        cfg.CONF.set_override('ipaddr_allow_fixed_ip', True, "QUARK")
         port = dict(id=1, network_id=2, ip_addresses=[])
         ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
                   subnet_id=1, network_id=2, version=4)
@@ -118,6 +124,22 @@ class TestIpAddresses(test_quark_plugin.TestQuarkPlugin):
             self.assertEqual(response['network_id'], ip["network_id"])
             self.assertEqual(response['port_ids'], [port["id"]])
             self.assertEqual(response['subnet_id'], ip['id'])
+        cfg.CONF.set_override('ipaddr_allow_fixed_ip', old_cfg, "QUARK")
+
+    def test_fail_create_ip_address_with_port_when_disallowed(self):
+        old_cfg = cfg.CONF.QUARK.ipaddr_allow_fixed_ip
+        cfg.CONF.set_override('ipaddr_allow_fixed_ip', False, "QUARK")
+        port = dict(id=1, network_id=2, ip_addresses=[])
+        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
+                  subnet_id=1, network_id=2, version=4)
+        with self._stubs(port=port, addr=ip):
+            ip_address = dict(port_ids=[port["id"]])
+            ip_address['version'] = 4
+            ip_address['network_id'] = 2
+            with self.assertRaises(exceptions.BadRequest):
+                self.plugin.create_ip_address(self.context,
+                                              dict(ip_address=ip_address))
+        cfg.CONF.set_override('ipaddr_allow_fixed_ip', old_cfg, "QUARK")
 
     def test_create_ip_address_by_device_no_network_fails(self):
         with self._stubs(port={}, addr=None):
@@ -134,6 +156,8 @@ class TestIpAddresses(test_quark_plugin.TestQuarkPlugin):
                 self.plugin.create_ip_address(self.context, ip_address)
 
     def test_create_ip_address_invalid_port(self):
+        old_cfg = cfg.CONF.QUARK.ipaddr_allow_fixed_ip
+        cfg.CONF.set_override('ipaddr_allow_fixed_ip', True, "QUARK")
         with self._stubs(port=None, addr=None):
             with self.assertRaises(exceptions.PortNotFound):
                 ip_address = {
@@ -144,46 +168,7 @@ class TestIpAddresses(test_quark_plugin.TestQuarkPlugin):
                     }
                 }
                 self.plugin.create_ip_address(self.context, ip_address)
-
-
-class TestCreateIpAddressQuotaCheck(test_quark_plugin.TestQuarkPlugin):
-    @contextlib.contextmanager
-    def _stubs(self, port, addresses):
-        port_model = models.Port()
-        port_model.update(port)
-
-        for addr in addresses:
-            addr_model = models.IPAddress()
-            addr_model.update(addr)
-            port_model["ip_addresses"].append(addr_model)
-
-        with contextlib.nested(
-            mock.patch("quark.db.api.network_find"),
-            mock.patch("quark.db.api.port_find"),
-            mock.patch("quark.plugin_modules.ip_addresses.ipam_driver"),
-            mock.patch("quark.plugin_modules.ip_addresses.db_api"
-                       ".port_associate_ip"),
-            mock.patch("quark.plugin_modules.ip_addresses"
-                       ".validate_and_fetch_segment")
-        ) as (net_f, port_find, mock_ipam, mock_port_associate_ip, validate):
-            port_find.return_value = port_model
-            yield
-
-    def test_create_ip_address_with_port_over_quota(self):
-        addresses = [{"id": ip, "address": ip} for ip in xrange(5)]
-        port = dict(id=1, network_id=2, ip_addresses=[])
-
-        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
-                  subnet_id=1, network_id=2, version=4)
-
-        with self._stubs(port=port, addresses=addresses):
-            ip_address = dict(port_ids=[port["id"]])
-            ip_address['version'] = 4
-            ip_address['network_id'] = 2
-
-            with self.assertRaises(exceptions.OverQuota):
-                self.plugin.create_ip_address(
-                    self.context, dict(ip_address=ip_address))
+        cfg.CONF.set_override('ipaddr_allow_fixed_ip', old_cfg, "QUARK")
 
 
 @mock.patch("quark.plugin_modules.ip_addresses.v")
@@ -205,6 +190,8 @@ class TestQuarkSharedIPAddressCreate(test_quark_plugin.TestQuarkPlugin):
 
     def test_create_ip_address_calls_port_associate_ip(self, mock_dbapi,
                                                        mock_ipam, *args):
+        old_cfg = cfg.CONF.QUARK.ipaddr_allow_fixed_ip
+        cfg.CONF.set_override('ipaddr_allow_fixed_ip', True, "QUARK")
         port = dict(id=1, network_id=2, ip_addresses=[])
         ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
                   subnet_id=1, network_id=2, version=4, tenant_id=1)
@@ -224,6 +211,7 @@ class TestQuarkSharedIPAddressCreate(test_quark_plugin.TestQuarkPlugin):
                                       dict(ip_address=ip_address))
         mock_dbapi.port_associate_ip.assert_called_once_with(
             self.context, [port_model], ip_model)
+        cfg.CONF.set_override('ipaddr_allow_fixed_ip', old_cfg, "QUARK")
 
     def test_create_ip_address_address_type_shared(self, mock_dbapi, mock_ipam,
                                                    *args):
@@ -258,6 +246,8 @@ class TestQuarkSharedIPAddressCreate(test_quark_plugin.TestQuarkPlugin):
     def test_create_ip_address_address_type_fixed(self, mock_dbapi, mock_ipam,
                                                   *args):
         cfg.CONF.set_override('ipam_reuse_after', 100, "QUARK")
+        old_cfg = cfg.CONF.QUARK.ipaddr_allow_fixed_ip
+        cfg.CONF.set_override('ipaddr_allow_fixed_ip', True, "QUARK")
         ports = [dict(id=1, network_id=2, ip_addresses=[])]
         ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
                   subnet_id=1, network_id=2, version=4, tenant_id=1)
@@ -283,6 +273,7 @@ class TestQuarkSharedIPAddressCreate(test_quark_plugin.TestQuarkPlugin):
             self.context, [ip_model], ip['network_id'], None, 100,
             version=ip_address['version'], ip_addresses=[],
             segment_id=None, address_type="fixed")
+        cfg.CONF.set_override('ipaddr_allow_fixed_ip', old_cfg, "QUARK")
 
 
 class TestQuarkSharedIPAddressPortsValid(test_quark_plugin.TestQuarkPlugin):
@@ -489,6 +480,20 @@ class TestQuarkUpdateIPAddress(test_quark_plugin.TestQuarkPlugin):
                                                      ip_address)
             self.assertEqual(response['port_ids'], [port['id']])
 
+    def test_bad_request_fixed_update_multiple_ports(self):
+        port1 = dict(id=1, network_id=2, ip_addresses=[])
+        port2 = dict(id=2, network_id=2, ip_addresses=[])
+        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
+                  subnet_id=1, network_id=2, version=4,
+                  address_type=ip_types.FIXED)
+        with self._stubs(ports=[port1, port2], addr=ip):
+            ip_address = {'ip_address': {'port_ids': [port1['id'],
+                                                      port2['id']],
+                                         'network_id': 2}}
+            with self.assertRaises(exceptions.BadRequest):
+                self.plugin.update_ip_address(self.context, ip['id'],
+                                              ip_address)
+
     def _create_patch(self, path):
         patcher = patch(path)
         mocked = patcher.start()
@@ -558,55 +563,6 @@ class TestQuarkUpdateIPAddress(test_quark_plugin.TestQuarkPlugin):
                                                      ip['id'],
                                                      ip_address)
             self.assertEqual(response['port_ids'], [])
-
-
-class TestQuarkUpdateIPAddressQuotaCheck(test_quark_plugin.TestQuarkPlugin):
-    @contextlib.contextmanager
-    def _stubs(self, port, addresses):
-        port_models = []
-        addr_model = None
-
-        port_model = models.Port()
-        port_model.update(port)
-        port_models.append(port_model)
-
-        for addr in addresses:
-            addr_model = models.IPAddress()
-            addr_model.update(addr)
-            port_model["ip_addresses"].append(addr_model)
-
-        db_mod = "quark.db.api"
-        with contextlib.nested(
-            mock.patch("%s.port_find" % db_mod),
-            mock.patch("%s.ip_address_find" % db_mod),
-            mock.patch("%s.port_associate_ip" % db_mod),
-            mock.patch("%s.port_disassociate_ip" % db_mod),
-            mock.patch("quark.plugin_modules.ip_addresses"
-                       ".validate_and_fetch_segment"),
-            mock.patch("quark.plugin_modules.ip_addresses.ipam_driver")
-        ) as (port_find, ip_find, port_associate_ip, port_disassociate_ip, val,
-              mock_ipam):
-            port_find.return_value = port_models
-            ip_find.return_value = addr_model
-            port_associate_ip.side_effect = _port_associate_stub
-            port_disassociate_ip.side_effect = _port_disassociate_stub
-            mock_ipam.deallocate_ip_address.side_effect = (
-                _ip_deallocate_stub)
-            yield
-
-    def test_update_ip_address_port_over_quota(self):
-        addresses = [{"id": ip, "address": ip} for ip in xrange(5)]
-
-        port = dict(id=1, network_id=2)
-        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
-                  subnet_id=1, network_id=2, version=4, deallocated=1,
-                  deallocated_at='2020-01-01 00:00:00')
-
-        with self._stubs(port=port, addresses=addresses):
-            ip_address = {'ip_address': {"port_ids": [port]}}
-            with self.assertRaises(exceptions.OverQuota):
-                self.plugin.update_ip_address(self.admin_context, ip['id'],
-                                              ip_address)
 
 
 class TestQuarkGetIpAddress(test_quark_plugin.TestQuarkPlugin):
@@ -814,66 +770,3 @@ class TestQuarkGetIpAddressPort(test_quark_plugin.TestQuarkPlugin):
         mock_dbapi.port_find.return_value = []
         with self.assertRaises(exceptions.PortNotFound):
             self.plugin.get_port_for_ip_address(self.context, 123, 100)
-
-    def test_update_port_service_inactive_ip(self, mock_dbapi, mock_ipam,
-                                             *args):
-        port = dict(id=100, network_id=2,
-                    backend_key="derp", device_id="y")
-        port2 = dict(id=101, network_id=2,
-                     backend_key="derp", device_id="x")
-        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
-                  subnet_id=1, network_id=2, version=4, address_type="shared")
-        port_model = models.Port()
-        port_model2 = models.Port()
-        port_model.update(port)
-        port_model2.update(port2)
-        ip_model = models.IPAddress()
-        ip_model.update(ip)
-        ip_model.ports = [port_model, port_model2]
-
-        ip_mod = 'quark.db.models.IPAddress'
-        mock_port_update = patch('%s.set_service_for_port' % ip_mod)
-        self.addCleanup(mock_port_update.stop)
-        mock_port_update = mock_port_update.start()
-
-        mock_dbapi.port_find.return_value = port_model
-        mock_dbapi.ip_address_find.return_value = ip_model
-        mock_ipam.allocate_ip_address.side_effect = (
-            self._alloc_stub(ip_model))
-        port_update = dict(service='derp')
-        port_update = {'port': port_update}
-        self.plugin.update_port_for_ip(self.context, 1, 100, port_update)
-        self.assertTrue(mock_port_update.called)
-        self.assertTrue(mock_port_update.called_once_with(
-            self.context, 100, port_update))
-
-    def test_update_shared_ip_deactivate(self, mock_dbapi, mock_ipam, *args):
-        port = dict(id=100, service='compute', network_id=2,
-                    backend_key="derp", device_id="y")
-        port2 = dict(id=101, network_id=2,
-                     backend_key="derp", device_id="x")
-        ip = dict(id=1, address=3232235876, address_readable="192.168.1.100",
-                  subnet_id=1, network_id=2, version=4, address_type="shared")
-        port_model = models.Port()
-        port_model2 = models.Port()
-        port_model.update(port)
-        port_model2.update(port2)
-        ip_model = models.IPAddress()
-        ip_model.update(ip)
-        ip_model.ports = [port_model, port_model2]
-
-        ip_mod = 'quark.db.models.IPAddress'
-        mock_port_update = patch('%s.set_service_for_port' % ip_mod)
-        self.addCleanup(mock_port_update.stop)
-        mock_port_update = mock_port_update.start()
-
-        mock_dbapi.port_find.return_value = port_model
-        mock_dbapi.ip_address_find.return_value = ip_model
-        mock_ipam.allocate_ip_address.side_effect = (
-            self._alloc_stub(ip_model))
-        port_update = dict(service='derp')
-        port_update = {'port': port_update}
-        self.plugin.update_port_for_ip(self.context, 1, 100, port_update)
-        self.assertTrue(mock_port_update.called)
-        self.assertTrue(mock_port_update.called_once_with(
-            self.context, 100, port_update))

--- a/quark/tests/plugin_modules/test_networks.py
+++ b/quark/tests/plugin_modules/test_networks.py
@@ -155,7 +155,8 @@ class TestQuarkGetNetworksShared(test_quark_plugin.TestQuarkPlugin):
                     self.assertEqual(1, len(net['subnets']))
             net_find.assert_called_with(self.context, None, None, None, False,
                                         None, join_subnets=True,
-                                        defaults=["public_network"])
+                                        defaults=["public_network"],
+                                        provider_query=False)
 
     def test_get_networks_shared_false(self):
         net0 = dict(id='public_network', tenant_id=self.context.tenant_id,
@@ -168,7 +169,8 @@ class TestQuarkGetNetworksShared(test_quark_plugin.TestQuarkPlugin):
                                      {"shared": [False]})
             net_find.assert_called_with(self.context, None, None, None, False,
                                         None, join_subnets=True,
-                                        defaults=[invert, "public_network"])
+                                        defaults=[invert, "public_network"],
+                                        provider_query=False)
 
     def test_get_networks_no_shared(self):
         net0 = dict(id='public_network', tenant_id=self.context.tenant_id,
@@ -179,7 +181,7 @@ class TestQuarkGetNetworksShared(test_quark_plugin.TestQuarkPlugin):
             self.plugin.get_networks(self.context, None, None, None, False)
             net_find.assert_called_with(self.context, None, None, None,
                                         False, None, join_subnets=True,
-                                        defaults=[])
+                                        defaults=[], provider_query=False)
 
 
 class TestQuarkGetNetworkCount(test_quark_plugin.TestQuarkPlugin):

--- a/quark/tests/plugin_modules/test_ports.py
+++ b/quark/tests/plugin_modules/test_ports.py
@@ -608,7 +608,8 @@ class TestQuarkPortCreateFixedIpsQuota(test_quark_plugin.TestQuarkPlugin):
     def test_create_port_fixed_ips_over_quota(self):
         network = {"id": 1, "tenant_id": self.context.tenant_id}
         fixed_ips = [{"subnet_id": 1}, {"subnet_id": 1}, {"subnet_id": 1},
-                     {"subnet_id": 1}, {"subnet_id": 1}, {"subnet_id": 1}]
+                     {"subnet_id": 1}, {"subnet_id": 1}, {"subnet_id": 1},
+                     {"subnet_id": 1}]
         port = {"port": {"network_id": 1, "tenant_id": self.context.tenant_id,
                          "device_id": 2, "fixed_ips": fixed_ips}}
         with self._stubs(network=network):
@@ -717,6 +718,7 @@ class TestQuarkUpdatePort(test_quark_plugin.TestQuarkPlugin):
 
     def test_update_port_goes_over_quota(self):
         fixed_ips = {"fixed_ips": [{"subnet_id": 1},
+                                   {"subnet_id": 1},
                                    {"subnet_id": 1},
                                    {"subnet_id": 1},
                                    {"subnet_id": 1},

--- a/quark/tests/test_db_api.py
+++ b/quark/tests/test_db_api.py
@@ -256,10 +256,12 @@ class TestDBAPI(BaseFunctionalTest):
         self.context.session.delete.assert_has_calls(
             [mock.call(mock_assocs[1]), mock.call(mock_assocs[2])])
 
+    @mock.patch("quark.db.api.get_ports_for_address")
     @mock.patch("quark.db.api.port_disassociate_ip")
     @mock.patch("quark.db.api.port_associate_ip")
     def test_update_port_associations_for_ip(self, associate_mock,
-                                             disassociate_mock):
+                                             disassociate_mock,
+                                             get_associations_mock):
         self.context.session.add = mock.Mock()
         self.context.session.delete = mock.Mock()
         mock_ports = [models.Port(id=str(x), network_id="2", ip_addresses=[])
@@ -272,6 +274,7 @@ class TestDBAPI(BaseFunctionalTest):
         new_port_list = mock_ports[1:3]
         new_port_list.append(models.Port(id="4", network_id="2",
                              ip_addresses=[]))
+        get_associations_mock.return_value = mock_ports
         # NOTE(thomasem): Should be the new address after associating
         # any new ports in the list.
         mock_new_address = associate_mock.return_value


### PR DESCRIPTION
Fixes JIRA:NCP-1612 JIRA:NCP-1613 JIRA:NCP-1617

Fixes quotas and disallows fixed_ip create

Fixes JIRA:NCP-1626 JIRA:NCP-1389

Bonus: JIRA:NCP-1592

Shared IP general fixes

Fixes JIRA:NCP-1389 added quota for total IPs/port/network with new conf:
    total_ips_allowed_on_port

Fixes JIRA:NCP-1444 added quota for shared-ips/network with new conf:
    shared_ips_allowed_on_network

Fixes JIRA:NCP-1592 prevents all fixed ip interactions

Fixes JIRA:NCP-1630 will now follow rules for 'service' checking

Fixes JIRA:NCP-1631 will now follow rules for 'service' checking

Fixes JIRA:NCP-1633 will check the request port length against the found port
    length

Put update_port_for_ip into context block

Fixes JIRA:NCP-1637

Conflicts:
	quark/exceptions.py
	quark/plugin.py
	quark/plugin_modules/ip_addresses.py
	quark/tests/plugin_modules/test_ports.py