### PR TITLE
(4 of 4) Tool to manage locks on null-routed addresses

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -85,7 +85,7 @@ def _model_query(context, model, filters, fields=None):
     filters = filters or {}
     model_filters = []
     eq_filters = ["address", "cidr", "deallocated", "ip_version", "service",
-                  "mac_address_range_id", "transaction_id"]
+                  "mac_address_range_id", "transaction_id", "lock_id"]
     in_filters = ["device_id", "device_owner", "group_id", "id", "mac_address",
                   "name", "network_id", "segment_id", "subnet_id",
                   "used_by_tenant_id", "version"]

--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -149,7 +149,8 @@ def _model_query(context, model, filters, fields=None):
         elif key == "tenant_id":
             if model == models.IPAddress:
                 model_filters.append(model.used_by_tenant_id.in_(value))
-            elif model == models.PortIpAssociation:
+            elif (model == models.PortIpAssociation or
+                  model == models.LockHolder):
                 pass
             else:
                 model_filters.append(model.tenant_id.in_(value))
@@ -934,3 +935,59 @@ def floating_ip_associate_fixed_ip(context, floating_ip, fixed_ip):
 def floating_ip_disassociate_fixed_ip(context, floating_ip):
     floating_ip.fixed_ip = None
     return floating_ip
+
+
+@scoped
+def lock_holder_find(context, **filters):
+    query = context.session.query(models.LockHolder)
+    model_filters = _model_query(context, models.LockHolder, filters)
+    return query.filter(*model_filters)
+
+
+def _lock_create(context, target, **kwargs):
+    with context.session.begin():
+        result = context.session.execute(
+            models.Lock.__table__.insert(),
+            {"type": kwargs["type"]})
+        lock_id = result.lastrowid
+
+        target_model = target.__class__
+        row_count = context.session.query(target_model).filter(
+            and_(target_model.id == target.id, target_model.lock_id.is_(None))
+        ).update(dict(lock_id=lock_id))
+
+    if row_count == 0:
+        context.session.query(models.Lock).filter(
+            models.Lock.id == lock_id).delete()
+        return None
+    return lock_id
+
+
+def lock_holder_create(context, target, **kwargs):
+    lock_id = target.lock_id
+    if not lock_id:
+        lock_id = _lock_create(context, target, **kwargs)
+        if not lock_id:
+            # Failed to concurrently create lock; invoker must retry
+            return
+    lock_holder = models.LockHolder(lock_id=lock_id,
+                                    name=kwargs["name"])
+    context.session.add(lock_holder)
+    return lock_holder
+
+
+def _lock_delete(context, target):
+    with context.session.begin():
+        lock_id = target.lock_id
+        lock_holder = lock_holder_find(context, lock_id=lock_id, scope=ONE)
+        if not lock_holder:
+            target.lock_id = None
+            context.session.add(target)
+            context.session.query(
+                models.Lock).filter(
+                    models.Lock.id == lock_id).delete()
+
+
+def lock_holder_delete(context, target, lock_holder):
+    context.session.delete(lock_holder)
+    _lock_delete(context, target)

--- a/quark/ip_availability.py
+++ b/quark/ip_availability.py
@@ -24,7 +24,7 @@ from neutron.db import api as neutron_db_api
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_utils import timeutils
-from sqlalchemy import and_, or_, func
+from sqlalchemy import and_, or_, func, not_
 
 from quark.db import models
 
@@ -108,7 +108,8 @@ def get_used_ips(session, **kwargs):
         query = query.outerjoin(
             models.IPAddress,
             and_(models.Subnet.id == models.IPAddress.subnet_id,
-                 or_(models.IPAddress._deallocated.is_(None),
+                 or_(not_(models.IPAddress.lock_id.is_(None)),
+                     models.IPAddress._deallocated.is_(None),
                      models.IPAddress._deallocated == 0,
                      models.IPAddress.deallocated_at > reuse_window)))
 

--- a/quark/ipam.py
+++ b/quark/ipam.py
@@ -367,6 +367,7 @@ class QuarkIpam(object):
             "network_id": net_id,
             "deallocated": True,
             "version": version,
+            "lock_id": None,
         }
         if reuse_after is not None:
             ip_kwargs["reuse_after"] = reuse_after

--- a/quark/tests/functional/mysql/test_locks.py
+++ b/quark/tests/functional/mysql/test_locks.py
@@ -1,0 +1,74 @@
+import netaddr
+
+from quark.db import api as db_api
+from quark.tests.functional.mysql.base import MySqlBaseFunctionalTest
+
+from oslo_log import log as logging
+
+LOG = logging.getLogger(__name__)
+
+
+class QuarkLocks(MySqlBaseFunctionalTest):
+    def test_create_lock_holder(self):
+        kwargs = {"address": netaddr.IPAddress("192.168.2.1")}
+        ip_address = db_api.ip_address_create(self.context, **kwargs)
+        kwargs = {"type": "ip_address", "name": "because i said so"}
+        lock_holder = db_api.lock_holder_create(
+            self.context, ip_address, **kwargs)
+
+        self.context.session.refresh(ip_address)
+        self.assertEqual(ip_address.lock_id, lock_holder.lock_id)
+
+    def test_create_lock_holder_already_locked(self):
+        kwargs = {"address": netaddr.IPAddress("192.168.2.1")}
+        ip_address = db_api.ip_address_create(self.context, **kwargs)
+        name = "because i said so"
+        kwargs_1 = {"type": "ip_address", "name": name + "1"}
+        lock_holder_1 = db_api.lock_holder_create(
+            self.context, ip_address, **kwargs_1)
+        self.context.session.flush()
+
+        kwargs_2 = {"type": "ip_address", "name": name + "2"}
+        self.context.session.refresh(ip_address)
+        lock_holder_2 = db_api.lock_holder_create(
+            self.context, ip_address, **kwargs_2)
+        self.context.session.flush()
+
+        self.context.session.refresh(ip_address)
+        self.assertNotEqual(lock_holder_1.id, lock_holder_2.id)
+        self.assertEqual(lock_holder_1.name, name + "1")
+        self.assertEqual(lock_holder_2.name, name + "2")
+        self.assertEqual(lock_holder_1.lock_id, lock_holder_2.lock_id)
+        self.assertEqual(ip_address.lock_id, lock_holder_1.lock_id)
+
+    def test_find_lock_holder(self):
+        kwargs = {"address": netaddr.IPAddress("192.168.2.1")}
+        ip_address = db_api.ip_address_create(self.context, **kwargs)
+        kwargs = {"type": "ip_address", "name": "because i said so"}
+        lock_holder = db_api.lock_holder_create(
+            self.context, ip_address, **kwargs)
+
+        self.context.session.refresh(ip_address)
+        self.assertEqual(ip_address.lock_id, lock_holder.lock_id)
+
+        lock_holders = db_api.lock_holder_find(
+            self.context,
+            lock_id=ip_address.lock_id, name=kwargs["name"],
+            scope=db_api.ALL)
+        self.assertEqual(len(lock_holders), 1)
+        self.assertEqual(lock_holders[0]["lock_id"], ip_address.lock_id)
+        self.assertEqual(lock_holders[0]["name"], kwargs["name"])
+
+    def test_delete_lock_holder(self):
+        kwargs = {"address": netaddr.IPAddress("192.168.2.1")}
+        ip_address = db_api.ip_address_create(self.context, **kwargs)
+        kwargs = {"type": "ip_address", "name": "because i said so"}
+        lock_holder = db_api.lock_holder_create(
+            self.context, ip_address, **kwargs)
+        self.context.session.flush()
+        self.context.session.refresh(ip_address)
+        self.assertEqual(ip_address.lock_id, lock_holder.lock_id)
+
+        db_api.lock_holder_delete(self.context, ip_address, lock_holder)
+        self.context.session.refresh(ip_address)
+        self.assertIsNone(ip_address.lock_id)

--- a/quark/tests/functional/mysql/test_null_routes.py
+++ b/quark/tests/functional/mysql/test_null_routes.py
@@ -1,0 +1,142 @@
+import mock
+import netaddr
+
+from quark.db import api as db_api
+from quark.tests.functional.mysql.base import MySqlBaseFunctionalTest
+from quark.tools import null_routes
+
+
+class TestNullRoutes(MySqlBaseFunctionalTest):
+    def setUp(self):
+        super(TestNullRoutes, self).setUp()
+        self.cidr = "192.168.10.0/24"
+        self.sub_cidr = "192.168.10.1/32"
+
+    def test_get_subnets_cidr_set(self):
+        network = db_api.network_create(self.context)
+        db_api.subnet_create(
+            self.context,
+            network=network, cidr=self.cidr)
+        self.context.session.flush()
+        ipset = null_routes.get_subnets_cidr_set(self.context, [network.id])
+        self.assertEqual(ipset, netaddr.IPSet(netaddr.IPNetwork(self.cidr)))
+
+    @mock.patch("requests.get")
+    def test_get_null_routes_addresses(self, get_method):
+        url, region = "TEST_URL", "TEST_REGION"
+        ipset = netaddr.IPSet(netaddr.IPNetwork(self.cidr))
+        payload = [{
+            "status": "1",
+            "note": None,
+            "updated": None,
+            "name": None,
+            "status_name": None,
+            "region.id": region,
+            "ip": None,
+            "idql": None,
+            "discovered": None,
+            "netmask": None,
+            "tag": None,
+            "conf": None,
+            "cidr": self.sub_cidr,
+            "id": None,
+            "switch.hostname": None,
+        }]
+        body = [{
+            "paginate": {
+                "total_count": len(payload),
+                "total_count_display": None,
+                "total_pages": None,
+                "author_comment": None,
+                "per_page": None,
+                "page": None
+            },
+            "request": None,
+            "payload": payload,
+            "response": None
+        }]
+        get_method.return_value.json.return_value = body
+        addresses = null_routes.get_null_routes_addresses(url, region, ipset)
+        get_method.assert_called_once_with(url, verify=False)
+        self.assertEqual(addresses,
+                         netaddr.IPSet(netaddr.IPNetwork(self.sub_cidr)))
+
+    def test_delete_locks_has_lock(self):
+        network = db_api.network_create(self.context)
+        address_model = db_api.ip_address_create(
+            self.context,
+            address=netaddr.IPAddress("192.168.10.1"),
+            network=network)
+        db_api.lock_holder_create(
+            self.context, address_model,
+            name=null_routes.LOCK_NAME, type="ip_address")
+        self.context.session.flush()
+
+        null_routes.delete_locks(self.context, [network.id], [])
+        self.context.session.refresh(address_model)
+        self.assertIsNone(address_model.lock_id)
+
+    def test_delete_locks_doesnt_have_lock(self):
+        network = db_api.network_create(self.context)
+        address_model = db_api.ip_address_create(
+            self.context,
+            address=netaddr.IPAddress("192.168.10.1"),
+            network=network)
+        db_api.lock_holder_create(
+            self.context, address_model,
+            name="not-null-routes", type="ip_address")
+        self.context.session.flush()
+
+        null_routes.delete_locks(self.context, [network.id], [])
+        self.context.session.refresh(address_model)
+        self.assertIsNotNone(address_model.lock_id)
+
+    def test_create_locks_address_doesnt_exist(self):
+        network = db_api.network_create(self.context)
+        subnet = db_api.subnet_create(
+            self.context,
+            network=network,
+            cidr=self.cidr,
+            ip_version=4)
+        self.context.session.flush()
+
+        addresses = netaddr.IPSet(netaddr.IPNetwork(self.sub_cidr))
+        null_routes.create_locks(self.context, [network.id], addresses)
+        address = db_api.ip_address_find(
+            self.context, subnet_id=subnet.id, scope=db_api.ONE)
+        self.assertIsNotNone(address)
+        self.assertIsNotNone(address.lock_id)
+
+    def test_create_locks_address_exists(self):
+        network = db_api.network_create(self.context)
+        address_model = db_api.ip_address_create(
+            self.context,
+            address=netaddr.IPAddress("192.168.10.1"),
+            network=network)
+        self.context.session.flush()
+
+        addresses = netaddr.IPSet(netaddr.IPNetwork(self.sub_cidr))
+        null_routes.create_locks(self.context, [network.id], addresses)
+        self.context.session.refresh(address_model)
+        self.assertIsNotNone(address_model.lock_id)
+
+    def test_create_locks_lock_holder_exists(self):
+        network = db_api.network_create(self.context)
+        address_model = db_api.ip_address_create(
+            self.context,
+            address=netaddr.IPAddress("192.168.10.1"),
+            network=network)
+        db_api.lock_holder_create(
+            self.context, address_model,
+            name=null_routes.LOCK_NAME, type="ip_address")
+        self.context.session.flush()
+
+        addresses = netaddr.IPSet(netaddr.IPNetwork(self.sub_cidr))
+        null_routes.create_locks(self.context, [network.id], addresses)
+
+        lock_holders = db_api.lock_holder_find(
+            self.context,
+            lock_id=address_model.lock_id,
+            name=null_routes.LOCK_NAME,
+            scope=db_api.ALL)
+        self.assertEqual(len(lock_holders), 1)

--- a/quark/tools/null_routes.py
+++ b/quark/tools/null_routes.py
@@ -1,0 +1,187 @@
+import sys
+
+import netaddr
+from neutron.common import config
+from neutron import context as neutron_context
+from oslo_config import cfg
+from oslo_log import log as logging
+import requests
+from sqlalchemy import not_
+
+from quark.db import api as db_api
+from quark.db import ip_types
+from quark.db import models
+
+
+CONF = cfg.CONF
+LOG = logging.getLogger(__name__)
+LOCK_NAME = "null-routed"
+
+null_routes_opts = [
+    cfg.StrOpt("null_routes_url",
+               help=_("URL to GET null routes data")),
+    cfg.StrOpt("null_routes_region",
+               help=_("region to filter null routes data")),
+    cfg.ListOpt("null_routes_network_ids",
+                default=["00000000-0000-0000-0000-000000000000"],
+                help=_("UUIDs of networks to query for null-routed IP "
+                       "addresses"))
+]
+
+CONF.register_opts(null_routes_opts, "QUARK")
+
+
+def main():
+    config.init(sys.argv[1:])
+    if not cfg.CONF.config_file:
+        sys.exit(_("ERROR: Unable to find configuration file via the default"
+                   " search paths (~/.neutron/, ~/, /etc/neutron/, /etc/) and"
+                   " the '--config-file' option!"))
+    config.setup_logging()
+
+    context = neutron_context.get_admin_context()
+    network_ids = cfg.CONF.QUARK.null_routes_network_ids
+    ipset = get_subnets_cidr_set(context, network_ids)
+
+    url = cfg.CONF.QUARK.null_routes_url
+    region = cfg.CONF.QUARK.null_routes_region
+    addresses = get_null_routes_addresses(url, region, ipset)
+
+    delete_locks(context, network_ids, addresses)
+    create_locks(context, network_ids, addresses)
+
+
+def get_subnets_cidr_set(context, network_ids):
+    ipset = netaddr.IPSet()
+    subnets = db_api.subnet_find(context, network_id=network_ids,
+                                 scope=db_api.ALL)
+    for subnet in subnets:
+        net = netaddr.IPNetwork(subnet["cidr"])
+        ipset.add(net)
+    return ipset
+
+
+def _make_request(url, region):
+    response = requests.get(url, verify=False)
+    data = response.json()
+
+    # NOTE(asadoughi): assertions to ensure schema hasn't changed
+    assert len(data) == 1
+    assert sorted(data[0].keys()) == sorted([
+        "paginate", "request", "payload", "response"])
+    assert sorted(data[0]["paginate"].keys()) == sorted([
+        "total_count", "total_count_display", "total_pages",
+        "author_comment", "per_page", "page"])
+    # NOTE(asadoughi): API response claims to be paged, but all the data is on
+    #                  the first page.
+    assert len(data[0]["payload"]) == data[0]["paginate"]["total_count"]
+
+    return data
+
+
+def get_null_routes_addresses(url, region, ipset):
+    data = _make_request(url, region)
+    addresses = netaddr.IPSet()
+    for datum in data[0]["payload"]:
+        assert sorted(datum.keys()) == sorted([
+            "status", "note", "updated", "name", "status_name",
+            "region.id", "ip", "idql", "discovered", "netmask", "tag",
+            "conf", "cidr", "id", "switch.hostname"])
+        net = netaddr.IPNetwork(datum["cidr"])
+        if datum["region.id"] != region or datum["status"] != "1":
+            continue
+        for addr in net:
+            if addr in ipset:
+                addresses.add(addr)
+    return addresses
+
+
+def _to_int(addr):
+    return int(addr.ipv6())
+
+
+def _find_addresses_to_be_unlocked(context, network_ids, addresses):
+    addresses = [_to_int(address) for address in addresses]
+    query = context.session.query(models.IPAddress)
+    query = query.filter(models.IPAddress.network_id.in_(network_ids))
+    if addresses:
+        query = query.filter(not_(models.IPAddress.address.in_(addresses)))
+    query = query.filter(not_(models.IPAddress.lock_id.is_(None)))
+    return query.all()
+
+
+def delete_locks(context, network_ids, addresses):
+    """Deletes locks for each IP address that is no longer null-routed."""
+    addresses_no_longer_null_routed = _find_addresses_to_be_unlocked(
+        context, network_ids, addresses)
+    LOG.info("Deleting %s lock holders on IPAddress with ids: %s",
+             len(addresses_no_longer_null_routed),
+             [addr.id for addr in addresses_no_longer_null_routed])
+
+    for address in addresses_no_longer_null_routed:
+        lock_holder = None
+        try:
+            lock_holder = db_api.lock_holder_find(
+                context, lock_id=address.lock_id, name=LOCK_NAME,
+                scope=db_api.ONE)
+            if lock_holder:
+                db_api.lock_holder_delete(context, address, lock_holder)
+        except Exception:
+            LOG.exception("Failed to delete lock holder %s", lock_holder)
+            continue
+    context.session.flush()
+
+
+def _find_or_create_address(context, network_ids, address):
+    address_model = db_api.ip_address_find(
+        context,
+        network_id=network_ids, address=_to_int(address), scope=db_api.ONE)
+    if not address_model:
+        query = context.session.query(models.Subnet)
+        query = query.filter(models.Subnet.network_id.in_(network_ids))
+        query = query.filter(models.Subnet.ip_version == address.version)
+        query = query.filter(_to_int(address) >= models.Subnet.first_ip)
+        query = query.filter(_to_int(address) <= models.Subnet.last_ip)
+        subnet = query.one()
+        address_model = db_api.ip_address_create(
+            context,
+            address=address,
+            subnet_id=subnet["id"],
+            version=subnet["ip_version"],
+            network_id=subnet["network_id"],
+            address_type=ip_types.FIXED)
+        address_model["deallocated"] = 1
+        context.session.add(address_model)
+    return address_model
+
+
+def create_locks(context, network_ids, addresses):
+    """Creates locks for each IP address that is null-routed.
+
+    The function creates the IP address if it is not present in the database.
+
+    """
+
+    for address in addresses:
+        address_model = None
+        try:
+            address_model = _find_or_create_address(
+                context, network_ids, address)
+            lock_holder = None
+            if address_model.lock_id:
+                lock_holder = db_api.lock_holder_find(
+                    context,
+                    lock_id=address_model.lock_id, name=LOCK_NAME,
+                    scope=db_api.ONE)
+
+            if not lock_holder:
+                LOG.info("Creating lock holder on IPAddress %s with id %s",
+                         address_model.address_readable,
+                         address_model.id)
+                db_api.lock_holder_create(
+                    context, address_model, name=LOCK_NAME, type="ip_address")
+        except Exception:
+            LOG.exception("Failed to create lock holder on IPAddress %s",
+                          address_model)
+            continue
+    context.session.flush()

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,4 @@ console_scripts =
     quark-agent = quark.agent.agent:main
     ip_availability = quark.ip_availability:main
     redis_sg_tool = quark.tools.redis_sg_tool:main
+    null_routes = quark.tools.null_routes:main


### PR DESCRIPTION
Creates and deletes lock holders for null-routed IP addresses.

JIRA:NCP-1624