### PR TITLE
Isolated security groups with conf toggle

### DIFF
--- a/quark/drivers/optimized_nvp_driver.py
+++ b/quark/drivers/optimized_nvp_driver.py
@@ -91,9 +91,11 @@ class OptimizedNVPDriver(NVPDriver):
     def update_port(self, context, port_id, status=True,
                     security_groups=None, **kwargs):
         security_groups = security_groups or []
+        mac_address = kwargs.get('mac_address')
+        device_id = kwargs.get('device_id')
         nvp_port = super(OptimizedNVPDriver, self).update_port(
-            context, port_id, status=status,
-            security_groups=security_groups)
+            context, port_id, mac_address=mac_address, device_id=device_id,
+            status=status, security_groups=security_groups)
         port = self._lport_select_by_id(context, port_id)
         port.update(nvp_port)
 

--- a/quark/environment.py
+++ b/quark/environment.py
@@ -21,6 +21,7 @@ CONF = cfg.CONF
 
 class Capabilities(object):
     SECURITY_GROUPS = "security_groups"
+    EGRESS = "egress"
 
 
 quark_opts = [

--- a/quark/exceptions.py
+++ b/quark/exceptions.py
@@ -116,9 +116,9 @@ class SecurityGroupsNotImplemented(exceptions.InvalidInput):
                 "create")
 
 
-class TenantNetworkSecurityGroupsNotImplemented(exceptions.InvalidInput):
-    message = _("Security Groups are not currently implemented for "
-                "tenant networks")
+class EgressSecurityGroupRulesNotEnabled(exceptions.InvalidInput):
+    message = _("Egress security group rules are not currently allowed "
+                "by environment_capabilities configuration.")
 
 
 class SecurityGroupsRequireDevice(exceptions.InvalidInput):

--- a/quark/tests/cache/test_security_groups_client.py
+++ b/quark/tests/cache/test_security_groups_client.py
@@ -23,6 +23,7 @@ import redis
 from quark.agent.xapi import VIF
 from quark.cache import security_groups_client as sg_client
 from quark.db import models
+from quark.environment import Capabilities
 from quark import exceptions as q_exc
 from quark.tests import test_base
 
@@ -33,6 +34,13 @@ class TestRedisSecurityGroupsClient(test_base.TestBase):
 
     def setUp(self):
         super(TestRedisSecurityGroupsClient, self).setUp()
+        # Forces the connection pool to be recreated on every test
+        sg_client.SecurityGroupsClient.connection_pool = None
+        temp_envcaps = [Capabilities.SECURITY_GROUPS, Capabilities.EGRESS]
+        CONF.set_override('environment_capabilities', temp_envcaps, 'QUARK')
+
+    def tearDown(self):
+        CONF.clear_override('environment_capabilities', 'QUARK')
 
     @mock.patch("uuid.uuid4")
     @mock.patch("quark.cache.redis_base.TwiceRedis")

--- a/quark/tests/plugin_modules/test_ports.py
+++ b/quark/tests/plugin_modules/test_ports.py
@@ -769,17 +769,6 @@ class TestQuarkUpdatePortSecurityGroups(test_quark_plugin.TestQuarkPlugin):
             yield (port_find, port_update, alloc_ip, dealloc_ip, sg_find,
                    driver_port_update)
 
-    def test_update_port_security_groups_on_tenant_net_raises(self):
-        with self._stubs(
-            port=dict(id=1, device_id="device")
-        ) as (port_find, port_update, alloc_ip, dealloc_ip, sg_find,
-              driver_port_update):
-            new_port = dict(port=dict(name="ourport",
-                                      security_groups=[1]))
-            with self.assertRaises(
-                    q_exc.TenantNetworkSecurityGroupsNotImplemented):
-                self.plugin.update_port(self.context, 1, new_port)
-
     def test_update_port_security_groups(self):
         with self._stubs(
             port=dict(id=1, device_id="device"), parent_net=True

--- a/quark/tests/test_nvp_driver.py
+++ b/quark/tests/test_nvp_driver.py
@@ -29,10 +29,10 @@ from quark.tests import test_base
 class TestNVPDriver(test_base.TestBase):
     def setUp(self):
         super(TestNVPDriver, self).setUp()
-
+        cfg.CONF.set_override('environment_capabilities', [], 'QUARK')
         if not hasattr(self, 'driver'):
             self.driver = quark.drivers.nvp_driver.NVPDriver()
-
+        cfg.CONF.clear_override('environment_capabilities', 'QUARK')
         cfg.CONF.set_override('max_rules_per_group', 3, 'NVP')
         cfg.CONF.set_override('max_rules_per_port', 1, 'NVP')
         self.driver.max_ports_per_switch = 0
@@ -491,6 +491,7 @@ class TestNVPDriverCreatePort(TestNVPDriver):
             self.assertTrue(False in status_args)
 
     def test_create_port_with_security_groups(self):
+        cfg.CONF.set_override('environment_capabilities', [], 'QUARK')
         with self._stubs() as connection:
             connection.securityprofile = self._create_security_profile()
             self.driver.create_port(self.context, self.net_id,
@@ -499,8 +500,10 @@ class TestNVPDriverCreatePort(TestNVPDriver):
             connection.lswitch_port().assert_has_calls([
                 mock.call.security_profiles([self.profile_id]),
             ], any_order=True)
+        cfg.CONF.clear_override('environment_capabilities', 'QUARK')
 
     def test_create_port_with_security_groups_max_rules(self):
+        cfg.CONF.set_override('environment_capabilities', [], 'QUARK')
         with self._stubs() as connection:
             connection.securityprofile = self._create_security_profile()
             connection.securityprofile().read().update(
@@ -512,6 +515,7 @@ class TestNVPDriverCreatePort(TestNVPDriver):
                 self.driver.create_port(
                     self.context, self.net_id, self.port_id,
                     security_groups=[1])
+        cfg.CONF.clear_override('environment_capabilities', 'QUARK')
 
 
 class TestNVPDriverUpdatePort(TestNVPDriver):
@@ -527,6 +531,7 @@ class TestNVPDriverUpdatePort(TestNVPDriver):
             yield connection
 
     def test_update_port(self):
+        cfg.CONF.set_override('environment_capabilities', [], 'QUARK')
         with self._stubs() as connection:
             self.driver.update_port(
                 self.context, self.port_id,
@@ -534,8 +539,10 @@ class TestNVPDriverUpdatePort(TestNVPDriver):
             connection.lswitch_port().assert_has_calls([
                 mock.call.security_profiles([self.profile_id]),
             ], any_order=True)
+        cfg.CONF.clear_override('environment_capabilities', 'QUARK')
 
     def test_update_port_max_rules(self):
+        cfg.CONF.set_override('environment_capabilities', [], 'QUARK')
         with self._stubs() as connection:
             connection.securityprofile().read().update(
                 {'logical_port_ingress_rules': [{'ethertype': 'IPv4'},
@@ -546,6 +553,7 @@ class TestNVPDriverUpdatePort(TestNVPDriver):
                 self.driver.update_port(
                     self.context, self.port_id,
                     security_groups=[1])
+        cfg.CONF.clear_override('environment_capabilities', 'QUARK')
 
 
 class TestNVPDriverLswitchesForNetwork(TestNVPDriver):


### PR DESCRIPTION
Allow isolated networks security groups using the
QUARK.environment_capabilities configuration value.

JIRA:NCP-1465
JIRA:NCP-1681