### PR TITLE
Raise different errors if it's a provider network

### DIFF
--- a/quark/exceptions.py
+++ b/quark/exceptions.py
@@ -95,6 +95,11 @@ class IPAddressProhibitedByPolicy(exceptions.InvalidInput):
     message = _("IP %(ip_addr)s is prohibited by policies on the subnet")
 
 
+class ProviderNetworkOutOfIps(exceptions.NeutronException):
+    message = _("Network %(net_id)s appears to be out of IP Addresses."
+                "You may want to try again in a few seconds")
+
+
 class IPPolicyNotFound(exceptions.NeutronException):
     message = _("IP Policy %(id)s not found.")
 


### PR DESCRIPTION
JIRA:NCP-1660

IPAM logic will now raise a different error for provider networks than
for tenant networks. The reasoning is the failure to have enough IP
addresses for a provider network is a provider problem, and therefore
should be a 500 error. Meanwhile, tenant network IP address failures
remain a 409, as that particular failure is still most likely on the
customer and their usage.