### PR TITLE
Remove unused network_strategy code

### DIFF
--- a/quark/ipam.py
+++ b/quark/ipam.py
@@ -118,7 +118,7 @@ def rfc3041_ip(port_id, cidr):
 
 
 def ip_address_failure(network_id):
-    if STRATEGY.is_parent_network(network_id):
+    if STRATEGY.is_provider_network(network_id):
         return q_exc.ProviderNetworkOutOfIps(net_id=network_id)
     else:
         return exceptions.IpAddressGenerationFailure(net_id=network_id)

--- a/quark/network_strategy.py
+++ b/quark/network_strategy.py
@@ -15,7 +15,6 @@
 
 import json
 
-from neutron.common import exceptions
 from oslo_config import cfg
 from oslo_log import log as logging
 
@@ -39,18 +38,13 @@ class JSONStrategy(object):
             self._compile_strategy(strategy)
 
     def _compile_strategy(self, strategy):
-        strategy = json.loads(strategy)
-        for network, definition in strategy.iteritems():
-            if "children" in definition:
-                for _, child_net in definition["children"].iteritems():
-                    self.reverse_strategy[child_net] = network
-        self.strategy = strategy
+        self.strategy = json.loads(strategy)
 
     def split_network_ids(self, context, net_ids):
         assignable = []
         tenant = []
         for net_id in net_ids:
-            if self.is_parent_network(net_id):
+            if self.is_provider_network(net_id):
                 assignable.append(net_id)
             else:
                 tenant.append(net_id)
@@ -62,25 +56,8 @@ class JSONStrategy(object):
     def get_assignable_networks(self, context):
         return self.strategy.keys()
 
-    def is_parent_network(self, net_id):
+    def is_provider_network(self, net_id):
         return self.strategy.get(net_id) is not None
-
-    def get_parent_network(self, net_id):
-        net = self.reverse_strategy.get(net_id)
-        if net:
-            return net
-
-        # No matches, this is the highest network
-        return net_id
-
-    def best_match_network_id(self, context, net_id, key):
-        net = self.strategy.get(net_id)
-        if net:
-            child_net = net["children"].get(key)
-            if not child_net:
-                raise exceptions.NetworkNotFound(net_id=net_id)
-            return child_net
-        return net_id
 
 
 STRATEGY = JSONStrategy()

--- a/quark/plugin_modules/subnets.py
+++ b/quark/plugin_modules/subnets.py
@@ -340,11 +340,6 @@ def get_subnet(context, id, fields=None):
     if not subnet:
         raise exceptions.SubnetNotFound(subnet_id=id)
 
-    # Check the network_id against the strategies
-    net_id = subnet["network_id"]
-    net_id = STRATEGY.get_parent_network(net_id)
-    subnet["network_id"] = net_id
-
     cache = subnet.get("_allocation_pool_cache")
     if not cache:
         new_cache = subnet.allocation_pools

--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -53,7 +53,7 @@ def _is_default_route(route):
 
 
 def _make_network_dict(network, fields=None):
-    shared_net = STRATEGY.is_parent_network(network["id"])
+    shared_net = STRATEGY.is_provider_network(network["id"])
     res = {"id": network["id"],
            "name": network.get("name"),
            "tenant_id": network.get("tenant_id"),
@@ -77,7 +77,7 @@ def _make_network_dict(network, fields=None):
 def _make_subnet_dict(subnet, fields=None):
     dns_nameservers = [str(netaddr.IPAddress(dns["ip"]))
                        for dns in subnet.get("dns_nameservers")]
-    net_id = STRATEGY.get_parent_network(subnet["network_id"])
+    net_id = subnet["network_id"]
 
     res = {"id": subnet.get("id"),
            "name": subnet.get("name"),
@@ -86,7 +86,7 @@ def _make_subnet_dict(subnet, fields=None):
            "ip_version": subnet.get("ip_version"),
            "dns_nameservers": dns_nameservers or [],
            "cidr": subnet.get("cidr"),
-           "shared": STRATEGY.is_parent_network(net_id),
+           "shared": STRATEGY.is_provider_network(net_id),
            "enable_dhcp": None}
 
     if CONF.QUARK.show_subnet_ip_policy_id:
@@ -163,7 +163,7 @@ def _ip_port_dict(ip, port, fields=None):
 def _port_dict(port, fields=None):
     res = {"id": port.get("id"),
            "name": port.get("name"),
-           "network_id": STRATEGY.get_parent_network(port["network_id"]),
+           "network_id": port["network_id"],
            "tenant_id": port.get("tenant_id"),
            "mac_address": port.get("mac_address"),
            "admin_state_up": port.get("admin_state_up"),
@@ -263,9 +263,8 @@ def _make_route_dict(route):
 
 
 def _make_ip_dict(address):
-    net_id = STRATEGY.get_parent_network(address["network_id"])
     return {"id": address["id"],
-            "network_id": net_id,
+            "network_id": address["network_id"],
             "address": address.formatted(),
             "port_ids": [assoc.port_id
                          for assoc in address["associations"]],

--- a/quark/tests/plugin_modules/test_ports.py
+++ b/quark/tests/plugin_modules/test_ports.py
@@ -452,7 +452,7 @@ class TestQuarkCreatePortsSameDevBadRequest(test_quark_plugin.TestQuarkPlugin):
             for key in expected.keys():
                 self.assertEqual(result[key], expected[key])
 
-    @mock.patch("quark.network_strategy.JSONStrategy.is_parent_network")
+    @mock.patch("quark.network_strategy.JSONStrategy.is_provider_network")
     def test_create_providernet_port_fixed_ip_not_authorized(self, is_parent):
         is_parent.return_value = True
         network = dict(id='1', tenant_id=self.context.tenant_id)
@@ -474,7 +474,7 @@ class TestQuarkCreatePortsSameDevBadRequest(test_quark_plugin.TestQuarkPlugin):
             with self.assertRaises(exceptions.NotAuthorized):
                 self.plugin.create_port(self.context, port)
 
-    @mock.patch("quark.network_strategy.JSONStrategy.is_parent_network")
+    @mock.patch("quark.network_strategy.JSONStrategy.is_provider_network")
     def test_create_providernet_port_fixed_ip_wrong_segment(self, is_parent):
         is_parent.return_value = True
         network = dict(id='1', tenant_id=self.context.tenant_id)
@@ -773,7 +773,7 @@ class TestQuarkUpdatePortSecurityGroups(test_quark_plugin.TestQuarkPlugin):
             mock.patch("quark.ipam.QuarkIpam.deallocate_ips_by_port"),
             mock.patch("neutron.quota.QuotaEngine.limit_check"),
             mock.patch("quark.plugin_modules.ports.STRATEGY"
-                       ".is_parent_network"),
+                       ".is_provider_network"),
             mock.patch("quark.db.api.security_group_find"),
             mock.patch("quark.drivers.base.BaseDriver.update_port")
         ) as (port_find, port_update, alloc_ip, dealloc_ip, limit_check,

--- a/quark/tests/test_network_strategies.py
+++ b/quark/tests/test_network_strategies.py
@@ -15,7 +15,6 @@
 
 import json
 
-from neutron.common import exceptions
 from oslo_config import cfg
 
 from quark import network_strategy
@@ -27,8 +26,7 @@ class TestJSONStrategy(test_base.TestBase):
         self.context = None
         self.strategy = {"public_network":
                          {"required": True,
-                          "bridge": "xenbr0",
-                          "children": {"nova": "child_net"}}}
+                          "bridge": "xenbr0"}}
         strategy_json = json.dumps(self.strategy)
         cfg.CONF.set_override("default_net_strategy", strategy_json, "QUARK")
 
@@ -57,31 +55,3 @@ class TestJSONStrategy(test_base.TestBase):
         self.assertTrue("foo_net" not in assignable)
         self.assertTrue("public_network" not in tenant)
         self.assertTrue("public_network" in assignable)
-
-    def test_get_parent_network(self):
-        json_strategy = network_strategy.JSONStrategy(None)
-        parent_net = json_strategy.get_parent_network("child_net")
-        self.assertEqual(parent_net, "public_network")
-
-    def test_get_parent_network_no_parent(self):
-        json_strategy = network_strategy.JSONStrategy(None)
-        parent_net = json_strategy.get_parent_network("bar_network")
-        self.assertEqual(parent_net, "bar_network")
-
-    def test_best_match_network_id(self):
-        json_strategy = network_strategy.JSONStrategy(None)
-        net = json_strategy.best_match_network_id(self.context,
-                                                  "public_network", "nova")
-        self.assertEqual(net, "child_net")
-
-    def test_best_match_network_net_not_in_strategy(self):
-        json_strategy = network_strategy.JSONStrategy(None)
-        net = json_strategy.best_match_network_id(self.context,
-                                                  "foo_net", "nova")
-        self.assertEqual(net, "foo_net")
-
-    def test_best_match_network_no_valid_child(self):
-        json_strategy = network_strategy.JSONStrategy(None)
-        with self.assertRaises(exceptions.NetworkNotFound):
-            json_strategy.best_match_network_id(self.context,
-                                                "public_network", "derpa")


### PR DESCRIPTION
JIRA:NCP-1580

Children of parent networks was a feature that went unused in quark,
and may as well be removed. Additionally, it changes the word "parent"
to be "provider" whereever this code is used. This patch acts as a
pre-cursor to the provider subnets implementation.