### PR TITLE
Fixed issue where floating ips were not cleaned up correctly on port delete

### DIFF
--- a/quark/drivers/floating_ip_registry.py
+++ b/quark/drivers/floating_ip_registry.py
@@ -13,8 +13,20 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from oslo_config import cfg
+
 from quark.drivers.registry import DriverRegistryBase
 from quark.drivers import unicorn_driver as unicorn
+
+CONF = cfg.CONF
+
+quark_router_opts = [
+    cfg.StrOpt('default_floating_ip_driver',
+               default='Unicorn',
+               help=_('Driver for floating IP')),
+]
+
+CONF.register_opts(quark_router_opts, 'QUARK')
 
 
 class FloatingIPDriverRegistry(DriverRegistryBase):
@@ -22,5 +34,13 @@ class FloatingIPDriverRegistry(DriverRegistryBase):
         self.drivers = {
             unicorn.UnicornDriver.get_name(): unicorn.UnicornDriver()}
 
+    def get_driver(self, driver_name=None):
+        if not driver_name:
+            driver_name = CONF.QUARK.default_floating_ip_driver
+
+        if driver_name in self.drivers:
+            return self.drivers[driver_name]
+
+        raise Exception("Driver %s is not registered." % driver_name)
 
 DRIVER_REGISTRY = FloatingIPDriverRegistry()

--- a/quark/plugin_modules/floating_ips.py
+++ b/quark/plugin_modules/floating_ips.py
@@ -29,9 +29,6 @@ CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
 quark_router_opts = [
-    cfg.StrOpt('default_floating_ip_driver',
-               default='Unicorn',
-               help=_('Driver for floating IP')),
     cfg.StrOpt('floating_ip_segment_name', default='floating_ip',
                help=_('Segment name for floating IP subnets')),
     cfg.StrOpt('floating_ip_ipam_strategy', default='ANY',
@@ -133,8 +130,7 @@ def create_floatingip(context, content):
             flip = db_api.floating_ip_associate_fixed_ip(context, flip,
                                                          fixed_ip)
 
-            flip_driver_type = CONF.QUARK.default_floating_ip_driver
-            flip_driver = registry.DRIVER_REGISTRY.get_driver(flip_driver_type)
+            flip_driver = registry.DRIVER_REGISTRY.get_driver()
 
             flip_driver.register_floating_ip(flip, port, fixed_ip)
 
@@ -206,8 +202,7 @@ def update_floatingip(context, id, content):
             flip = db_api.port_associate_ip(context, [port], flip, [port_id])
             flip = db_api.floating_ip_associate_fixed_ip(context, flip,
                                                          fixed_ip)
-        flip_driver_type = CONF.QUARK.default_floating_ip_driver
-        flip_driver = registry.DRIVER_REGISTRY.get_driver(flip_driver_type)
+        flip_driver = registry.DRIVER_REGISTRY.get_driver()
 
         if port:
             if current_port:
@@ -261,8 +256,7 @@ def delete_floatingip(context, id):
         db_api.ip_address_deallocate(context, flip)
 
     if flip.fixed_ip:
-        driver_type = CONF.QUARK.default_floating_ip_driver
-        driver = registry.DRIVER_REGISTRY.get_driver(driver_type)
+        driver = registry.DRIVER_REGISTRY.get_driver()
         driver.remove_floating_ip(flip)
 
 


### PR DESCRIPTION
Fixes JIRA:NCP-1724
Fixes JIRA:NDP-749

This modifies the port delete process to check ip address before deallocating to see if it is a floating ip.  If it is a floating ip then it does not need to be deallocated, but the fixed ip does need to be disassociated.