### PR TITLE
Implements provider subnets

### DIFF
--- a/insert_provider_subnets.py
+++ b/insert_provider_subnets.py
@@ -1,0 +1,52 @@
+import sys
+
+from neutron.common import config
+from neutron.db import api as neutron_db_api
+from oslo_config import cfg
+
+from quark.db import models
+
+
+def main():
+    config.init(sys.argv[1:])
+    if not cfg.CONF.config_file:
+        sys.exit(_("ERROR: Unable to find configuration file via the default"
+                   " search paths (~/.neutron/, ~/, /etc/neutron/, /etc/) and"
+                   " the '--config-file' option!"))
+
+    config.setup_logging()
+    session = neutron_db_api.get_session()
+    subnets = [
+        models.Subnet(name="public_v4",
+                      network_id="00000000-0000-0000-0000-000000000000",
+                      id="00000000-0000-0000-0000-000000000000",
+                      tenant_id="rackspace",
+                      segment_id="rackspace",
+                      do_not_use=True,
+                      _cidr="0.0.0.0/0"),
+        models.Subnet(name="public_v6",
+                      network_id="00000000-0000-0000-0000-000000000000",
+                      id="11111111-1111-1111-1111-111111111111",
+                      tenant_id="rackspace",
+                      segment_id="rackspace",
+                      do_not_use=True,
+                      _cidr="::/0"),
+        models.Subnet(name="private_v4",
+                      network_id="11111111-1111-1111-1111-111111111111",
+                      id="22222222-2222-2222-2222-222222222222",
+                      tenant_id="rackspace",
+                      segment_id="rackspace",
+                      do_not_use=True,
+                      _cidr="0.0.0.0/0"),
+        models.Subnet(name="private_v6",
+                      network_id="11111111-1111-1111-1111-111111111111",
+                      id="33333333-3333-3333-3333-333333333333",
+                      tenant_id="rackspace",
+                      segment_id="rackspace",
+                      do_not_use=True,
+                      _cidr="::/0")]
+    session.bulk_save_objects(subnets)
+
+
+if __name__ == "__main__":
+    main()

--- a/quark/drivers/unmanaged.py
+++ b/quark/drivers/unmanaged.py
@@ -57,7 +57,7 @@ class UnmanagedDriver(object):
     def create_port(self, context, network_id, port_id, **kwargs):
         LOG.info("create_port %s %s %s" % (context.tenant_id, network_id,
                                            port_id))
-        bridge_name = STRATEGY.get_network(context, network_id)["bridge"]
+        bridge_name = STRATEGY.get_network(network_id)["bridge"]
         return {"uuid": port_id, "bridge": bridge_name}
 
     def update_port(self, context, port_id, **kwargs):

--- a/quark/plugin_modules/subnets.py
+++ b/quark/plugin_modules/subnets.py
@@ -369,9 +369,10 @@ def get_subnets(context, limit=None, page_reverse=False, sorts=None,
     """
     LOG.info("get_subnets for tenant %s with filters %s fields %s" %
              (context.tenant_id, filters, fields))
+    filters = filters or {}
     subnets = db_api.subnet_find(context, limit=limit,
                                  page_reverse=page_reverse, sorts=sorts,
-                                 marker=marker,
+                                 marker_obj=marker,
                                  join_dns=True, join_routes=True, **filters)
     for subnet in subnets:
         cache = subnet.get("_allocation_pool_cache")

--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -71,16 +71,20 @@ def _make_network_dict(network, fields=None):
         else:
             res["subnets"] = [s["id"] for s in network.get("subnets", [])]
     else:
-        res["subnets"] = []
+        res["subnets"] = STRATEGY.subnet_ids_for_network(network["id"])
     return res
 
 
 def _make_subnet_dict(subnet, fields=None):
     dns_nameservers = [str(netaddr.IPAddress(dns["ip"]))
-                       for dns in subnet.get("dns_nameservers")]
-    net_id = subnet["network_id"]
+                       for dns in subnet.get("dns_nameservers", [])]
+    subnet_id = subnet.get("id")
+    if STRATEGY.is_provider_subnet(subnet_id):
+        net_id = STRATEGY.get_network_for_subnet(subnet_id)
+    else:
+        net_id = subnet["network_id"]
 
-    res = {"id": subnet.get("id"),
+    res = {"id": subnet_id,
            "name": subnet.get("name"),
            "tenant_id": subnet.get("tenant_id"),
            "network_id": net_id,
@@ -93,7 +97,8 @@ def _make_subnet_dict(subnet, fields=None):
     if CONF.QUARK.show_subnet_ip_policy_id:
         res['ip_policy_id'] = subnet.get("ip_policy_id")
 
-    if CONF.QUARK.show_allocation_pools:
+    if (CONF.QUARK.show_allocation_pools and not
+            STRATEGY.is_provider_subnet(subnet_id)):
         res["allocation_pools"] = subnet.allocation_pools
     else:
         res["allocation_pools"] = []
@@ -102,11 +107,10 @@ def _make_subnet_dict(subnet, fields=None):
         return {"destination": route["cidr"],
                 "nexthop": route["gateway"]}
 
-    # TODO(mdietz): really inefficient, should go away
     res["gateway_ip"] = None
     res["host_routes"] = []
     default_found = False
-    for route in subnet["routes"]:
+    for route in subnet.get("routes", []):
         netroute = netaddr.IPNetwork(route["cidr"])
         if _is_default_route(netroute):
             # NOTE(mdietz): This has the potential to find more than one
@@ -252,8 +256,7 @@ def _make_ports_list(query, fields=None):
 def _make_subnets_list(query, fields=None):
     subnets = []
     for subnet in query:
-        subnet_dict = _make_subnet_dict(subnet, fields=fields)
-        subnets.append(subnet_dict)
+        subnets.append(_make_subnet_dict(subnet, fields=fields))
     return subnets
 
 

--- a/quark/tests/plugin_modules/test_networks.py
+++ b/quark/tests/plugin_modules/test_networks.py
@@ -92,9 +92,8 @@ class TestQuarkGetNetworksShared(test_quark_plugin.TestQuarkPlugin):
     def setUp(self):
         super(TestQuarkGetNetworksShared, self).setUp()
         self.strategy = {"public_network":
-                         {"required": True,
-                          "bridge": "xenbr0",
-                          "children": {"nova": "child_net"}}}
+                         {"bridge": "xenbr0",
+                          "subnets": ["public_v4", "public_v6"]}}
         self.strategy_json = json.dumps(self.strategy)
         self.old = plugin_views.STRATEGY
         plugin_views.STRATEGY = network_strategy.JSONStrategy(
@@ -150,7 +149,7 @@ class TestQuarkGetNetworksShared(test_quark_plugin.TestQuarkPlugin):
             """ Includes regression for RM8483. """
             for net in ret:
                 if net['shared']:
-                    self.assertEqual(0, len(net['subnets']))
+                    self.assertEqual(2, len(net['subnets']))
                 else:
                     self.assertEqual(1, len(net['subnets']))
             net_find.assert_called_with(self.context, None, None, None, False,

--- a/quark/tests/plugin_modules/test_ports.py
+++ b/quark/tests/plugin_modules/test_ports.py
@@ -267,9 +267,11 @@ class TestQuarkCreatePortRM9305(test_quark_plugin.TestQuarkPlugin):
     def setUp(self):
         super(TestQuarkCreatePortRM9305, self).setUp()
         strategy = {"00000000-0000-0000-0000-000000000000":
-                    {"bridge": "publicnet"},
+                    {"bridge": "publicnet",
+                     "subnets": ["public_v4", "public_v6"]},
                     "11111111-1111-1111-1111-111111111111":
-                    {"bridge": "servicenet"}}
+                    {"bridge": "servicenet",
+                     "subnets": ["private_v4", "private_v6"]}}
         strategy_json = json.dumps(strategy)
         quark_ports.STRATEGY = network_strategy.JSONStrategy(strategy_json)
 
@@ -936,9 +938,8 @@ class TestQuarkCreatePortOnSharedNetworks(test_quark_plugin.TestQuarkPlugin):
     @contextlib.contextmanager
     def _stubs(self, port=None, network=None, addr=None, mac=None):
         self.strategy = {"public_network":
-                         {"required": True,
-                          "bridge": "xenbr0",
-                          "children": {"nova": "child_net"}}}
+                         {"bridge": "xenbr0",
+                          "subnets": ["public_v4", "public_v6"]}}
         strategy_json = json.dumps(self.strategy)
         quark_ports.STRATEGY = network_strategy.JSONStrategy(strategy_json)
 

--- a/quark/tests/test_ipam.py
+++ b/quark/tests/test_ipam.py
@@ -2166,9 +2166,11 @@ class QuarkIpamTestIpAddressFailure(test_base.TestBase):
     def setUp(self):
         super(QuarkIpamTestIpAddressFailure, self).setUp()
         strategy = {"00000000-0000-0000-0000-000000000000":
-                    {"bridge": "publicnet"},
+                    {"bridge": "publicnet",
+                     "subnets": ["public_v4", "public_v6"]},
                     "11111111-1111-1111-1111-111111111111":
-                    {"bridge": "servicenet"}}
+                    {"bridge": "servicenet",
+                     "subnets": ["private_v4", "private_v6"]}}
         strategy_json = json.dumps(strategy)
         quark.ipam.STRATEGY = network_strategy.JSONStrategy(strategy_json)
 

--- a/quark/tests/test_unmanaged_driver.py
+++ b/quark/tests/test_unmanaged_driver.py
@@ -27,7 +27,8 @@ from quark.tests import test_base
 class TestUnmanagedDriver(test_base.TestBase):
     def setUp(self):
         super(TestUnmanagedDriver, self).setUp()
-        self.strategy = {"public_network": {"bridge": "xenbr0"}}
+        self.strategy = {"public_network": {"bridge": "xenbr0",
+                                            "subnets": ["public"]}}
         strategy_json = json.dumps(self.strategy)
         self.driver = unmanaged.UnmanagedDriver()
         unmanaged.STRATEGY = network_strategy.JSONStrategy(strategy_json)


### PR DESCRIPTION
JIRA:NCP-1580

Implements hooks for showing provider subnets, which are merely aliases
for subnets owned by provider networks. Unlike provider networks, they
are merely placeholders and will never be related in the schema to any
other object.