### PR TITLE
Exclude provider subnets from overlapping CIDR validation

### DIFF
--- a/quark/plugin_modules/subnets.py
+++ b/quark/plugin_modules/subnets.py
@@ -65,7 +65,8 @@ def _validate_subnet_cidr(context, network_id, new_subnet_cidr):
 
     # Using admin context here, in case we actually share networks later
     subnet_list = db_api.subnet_find(context.elevated(), None, None, None,
-                                     False, network_id=network_id)
+                                     False, network_id=network_id,
+                                     shared=[False])
     for subnet in subnet_list:
         if (netaddr.IPSet([subnet.cidr]) & new_subnet_ipset):
             # don't give out details of the overlapping subnet


### PR DESCRIPTION
Including the provider subnets as part of the validation caused
a BadRequest as their cidrs span the entire IP space. This would
prevent quark administrators creating any new subnets under provider
networks.

JIRA:NCP-1746