### PR TITLE
Exclude provider subnets from query

### DIFF
--- a/quark/tools/null_routes.py
+++ b/quark/tools/null_routes.py
@@ -39,6 +39,13 @@ def main():
                    " the '--config-file' option!"))
     config.setup_logging()
 
+    # NOTE(asadoughi): Reload quark-based python modules to re-initialize
+    # singletons that depend on configuration,
+    # such as quark.network_strategy.JSONStrategy.
+    reload(db_api)
+    reload(ip_types)
+    reload(models)
+
     context = neutron_context.get_admin_context()
     network_ids = cfg.CONF.QUARK.null_routes_network_ids
     ipset = get_subnets_cidr_set(context, network_ids)
@@ -54,7 +61,7 @@ def main():
 def get_subnets_cidr_set(context, network_ids):
     ipset = netaddr.IPSet()
     subnets = db_api.subnet_find(context, network_id=network_ids,
-                                 scope=db_api.ALL)
+                                 shared=[False])
     for subnet in subnets:
         net = netaddr.IPNetwork(subnet["cidr"])
         ipset.add(net)


### PR DESCRIPTION
Provider subnets' CIDRs span the entire IP space, so including them
causes issues for null_routes. We exclude them by setting shared
to False on the subnet_find as well as reloading python modules
so they can use the appropriately initialized default_net_strategy
configuration parameter.

JIRA:NCP-1749