### PR TITLE
Reload network strategy configuration explicitly

### DIFF
--- a/quark/network_strategy.py
+++ b/quark/network_strategy.py
@@ -32,6 +32,9 @@ class JSONStrategy(object):
     def __init__(self, strategy=None):
         self.subnet_strategy = {}
         self.strategy = {}
+        self.load(strategy)
+
+    def load(self, strategy=None):
         if not strategy:
             self._compile_strategy(CONF.QUARK.default_net_strategy)
         else:

--- a/quark/tools/null_routes.py
+++ b/quark/tools/null_routes.py
@@ -39,12 +39,9 @@ def main():
                    " the '--config-file' option!"))
     config.setup_logging()
 
-    # NOTE(asadoughi): Reload quark-based python modules to re-initialize
-    # singletons that depend on configuration,
-    # such as quark.network_strategy.JSONStrategy.
-    reload(db_api)
-    reload(ip_types)
-    reload(models)
+    # Reload configuration for network strategy
+    from quark import network_strategy
+    network_strategy.STRATEGY.load()
 
     context = neutron_context.get_admin_context()
     network_ids = cfg.CONF.QUARK.null_routes_network_ids


### PR DESCRIPTION
Configuration is loaded upon import of module and reload() did not
work as expected at every execution of null_routes so explicitly
reload the network strategy instead to work around the issue.

JIRA:NCP-1749