### PR TITLE
Modifies responses to return provider subnet IDs

### DIFF
--- a/quark/network_strategy.py
+++ b/quark/network_strategy.py
@@ -43,8 +43,9 @@ class JSONStrategy(object):
     def _compile_strategy(self, strategy):
         self.strategy = json.loads(strategy)
         for net_id, meta in self.strategy.iteritems():
-            for subnet_id in meta["subnets"]:
-                self.subnet_strategy[subnet_id] = net_id
+            for ip_version, subnet_id in meta["subnets"].iteritems():
+                self.subnet_strategy[subnet_id] = {"ip_version": ip_version,
+                                                   "network_id": net_id}
 
     def _split(self, func, resource_ids):
         provider = []
@@ -68,6 +69,11 @@ class JSONStrategy(object):
     def get_provider_subnets(self):
         return sorted(self.subnet_strategy.keys())
 
+    def get_provider_subnet_id(self, net_id, ip_version):
+        if net_id not in self.strategy:
+            return None
+        return self.strategy[net_id]["subnets"][str(ip_version)]
+
     def get_network(self, net_id):
         return self.strategy.get(net_id)
 
@@ -79,10 +85,13 @@ class JSONStrategy(object):
 
     def subnet_ids_for_network(self, net_id):
         if net_id in self.strategy:
-            return self.strategy.get(net_id)["subnets"]
+            subnets = self.strategy.get(net_id)["subnets"]
+            return [subnet_id for ip_version, subnet_id in subnets.iteritems()]
 
     def get_network_for_subnet(self, subnet_id):
-        return self.subnet_strategy.get(subnet_id)
+        if subnet_id not in self.subnet_strategy:
+            return None
+        return self.subnet_strategy.get(subnet_id)["network_id"]
 
 
 STRATEGY = JSONStrategy()

--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -205,7 +205,12 @@ def _port_dict(port, fields=None):
 
 def _make_port_address_dict(ip, port, fields=None):
     enabled = ip.enabled_for_port(port)
-    ip_addr = {"subnet_id": ip.get("subnet_id"),
+    subnet_id = ip.get("subnet_id")
+    net_id = ip.get("network_id")
+    if STRATEGY.is_provider_network(net_id):
+        subnet_id = STRATEGY.get_provider_subnet_id(net_id, ip["version"])
+
+    ip_addr = {"subnet_id": subnet_id,
                "ip_address": ip.formatted(),
                "enabled": enabled}
     if fields and "port_subnets" in fields:

--- a/quark/tests/plugin_modules/test_networks.py
+++ b/quark/tests/plugin_modules/test_networks.py
@@ -93,7 +93,8 @@ class TestQuarkGetNetworksShared(test_quark_plugin.TestQuarkPlugin):
         super(TestQuarkGetNetworksShared, self).setUp()
         self.strategy = {"public_network":
                          {"bridge": "xenbr0",
-                          "subnets": ["public_v4", "public_v6"]}}
+                          "subnets": {"4": "public_v4",
+                                      "6": "public_v6"}}}
         self.strategy_json = json.dumps(self.strategy)
         self.old = plugin_views.STRATEGY
         plugin_views.STRATEGY = network_strategy.JSONStrategy(

--- a/quark/tests/plugin_modules/test_ports.py
+++ b/quark/tests/plugin_modules/test_ports.py
@@ -268,10 +268,12 @@ class TestQuarkCreatePortRM9305(test_quark_plugin.TestQuarkPlugin):
         super(TestQuarkCreatePortRM9305, self).setUp()
         strategy = {"00000000-0000-0000-0000-000000000000":
                     {"bridge": "publicnet",
-                     "subnets": ["public_v4", "public_v6"]},
+                     "subnets": {"4": "public_v4",
+                                 "6": "public_v6"}},
                     "11111111-1111-1111-1111-111111111111":
                     {"bridge": "servicenet",
-                     "subnets": ["private_v4", "private_v6"]}}
+                     "subnets": {"4": "private_v4",
+                                 "6": "private_v6"}}}
         strategy_json = json.dumps(strategy)
         quark_ports.STRATEGY = network_strategy.JSONStrategy(strategy_json)
 
@@ -939,7 +941,8 @@ class TestQuarkCreatePortOnSharedNetworks(test_quark_plugin.TestQuarkPlugin):
     def _stubs(self, port=None, network=None, addr=None, mac=None):
         self.strategy = {"public_network":
                          {"bridge": "xenbr0",
-                          "subnets": ["public_v4", "public_v6"]}}
+                          "subnets": {"4": "public_v4",
+                                      "6": "public_v6"}}}
         strategy_json = json.dumps(self.strategy)
         quark_ports.STRATEGY = network_strategy.JSONStrategy(strategy_json)
 

--- a/quark/tests/plugin_modules/test_subnets.py
+++ b/quark/tests/plugin_modules/test_subnets.py
@@ -1602,7 +1602,8 @@ class TestQuarkGetSubnetsShared(test_quark_plugin.TestQuarkPlugin):
         super(TestQuarkGetSubnetsShared, self).setUp()
         self.strategy = {"public_network":
                          {"bridge": "xenbr0",
-                          "subnets": ["public_v4", "public_v6"]}}
+                          "subnets": {"4": "public_v4",
+                                      "6": "public_v6"}}}
         self.strategy_json = json.dumps(self.strategy)
         self.old = plugin_views.STRATEGY
         plugin_views.STRATEGY = network_strategy.JSONStrategy(

--- a/quark/tests/test_ipam.py
+++ b/quark/tests/test_ipam.py
@@ -2167,10 +2167,12 @@ class QuarkIpamTestIpAddressFailure(test_base.TestBase):
         super(QuarkIpamTestIpAddressFailure, self).setUp()
         strategy = {"00000000-0000-0000-0000-000000000000":
                     {"bridge": "publicnet",
-                     "subnets": ["public_v4", "public_v6"]},
+                     "subnets": {"4": "public_v4",
+                                 "6": "public_v6"}},
                     "11111111-1111-1111-1111-111111111111":
                     {"bridge": "servicenet",
-                     "subnets": ["private_v4", "private_v6"]}}
+                     "subnets": {"4": "private_v4",
+                                 "6": "private_v6"}}}
         strategy_json = json.dumps(strategy)
         quark.ipam.STRATEGY = network_strategy.JSONStrategy(strategy_json)
 

--- a/quark/tests/test_network_strategies.py
+++ b/quark/tests/test_network_strategies.py
@@ -24,8 +24,8 @@ from quark.tests import test_base
 class TestJSONStrategy(test_base.TestBase):
     def setUp(self):
         self.strategy = {"public_network": {"bridge": "xenbr0",
-                                            "subnets": ["public_v4",
-                                                        "public_v6"]}}
+                                            "subnets": {"4": "public_v4",
+                                                        "6": "public_v6"}}}
         strategy_json = json.dumps(self.strategy)
         cfg.CONF.set_override("default_net_strategy", strategy_json, "QUARK")
 
@@ -105,3 +105,17 @@ class TestJSONStrategy(test_base.TestBase):
         json_strategy = network_strategy.JSONStrategy()
         subs = json_strategy.subnet_ids_for_network("tenant_network")
         self.assertIsNone(subs)
+
+    def test_get_provider_subnet_id(self):
+        json_strategy = network_strategy.JSONStrategy()
+        net_id = "public_network"
+        ip_version = 4
+        sub = json_strategy.get_provider_subnet_id(net_id, ip_version)
+        self.assertEqual(sub, "public_v4")
+
+    def test_get_provider_subnet_id_matches_none(self):
+        json_strategy = network_strategy.JSONStrategy()
+        net_id = "tenant_network"
+        ip_version = 4
+        sub = json_strategy.get_provider_subnet_id(net_id, ip_version)
+        self.assertIsNone(sub)

--- a/quark/tests/test_unmanaged_driver.py
+++ b/quark/tests/test_unmanaged_driver.py
@@ -28,7 +28,7 @@ class TestUnmanagedDriver(test_base.TestBase):
     def setUp(self):
         super(TestUnmanagedDriver, self).setUp()
         self.strategy = {"public_network": {"bridge": "xenbr0",
-                                            "subnets": ["public"]}}
+                                            "subnets": {"4": "public"}}}
         strategy_json = json.dumps(self.strategy)
         self.driver = unmanaged.UnmanagedDriver()
         unmanaged.STRATEGY = network_strategy.JSONStrategy(strategy_json)


### PR DESCRIPTION
JIRA:NCP-1580

Updates the port view functionality to replace the real subnet_id with a
provider one. Necessitates updating the config again to incorporate the
ip_version in the provider subnet variable.