### PR TITLE
Create empty neutron.conf file for unit tests

### DIFF
--- a/quark/tests/test_base.py
+++ b/quark/tests/test_base.py
@@ -30,6 +30,11 @@ class TestBase(unittest2.TestCase):
         cfg.CONF.set_override('state_path', tox_path)
 
         neutron_conf_path = "%s/etc/neutron/neutron.conf" % tox_path
+        try:
+            open(neutron_conf_path, "r")
+        except IOError:
+            open(neutron_conf_path, "w")
+
         args = ['--config-file', neutron_conf_path]
         config.init(args=args)
 


### PR DESCRIPTION
The contents of the configuration file do not actually matter
since every configuration has a default.

Upstream neutron removed the previous neutron.conf sample at
112c8dd11d6f746b2b478f83061b63842838b495