### PR TITLE
Made insert_provider_subnets idempotent

### DIFF
--- a/quark/tools/insert_provider_subnets.py
+++ b/quark/tools/insert_provider_subnets.py
@@ -3,8 +3,12 @@ import sys
 from neutron.common import config
 from neutron.db import api as neutron_db_api
 from oslo_config import cfg
+from oslo_db.exception import DBDuplicateEntry
+from oslo_log import log as logging
 
 from quark.db import models
+
+LOG = logging.getLogger(__name__)
 
 
 def main():
@@ -45,7 +49,10 @@ def main():
                       segment_id="rackspace",
                       do_not_use=True,
                       _cidr="::/0")]
-    session.bulk_save_objects(subnets)
+    try:
+        session.bulk_save_objects(subnets)
+    except DBDuplicateEntry:
+        LOG.warn("Provider subnets previously inserted into database")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
insert_provider_subnets catches DBDuplicateEntry exception and
warns user if data has been previously inserted.

JIRA:NCP-1768