### PR TITLE
Proxy backend driver

### DIFF
--- a/quark/api/extensions/ports_quark.py
+++ b/quark/api/extensions/ports_quark.py
@@ -49,7 +49,11 @@ EXTENDED_ATTRIBUTES_2_0 = {
             "is_visible": True},
         "network_plugin": {"allow_post": True, "allow_put": False,
                            "enforce_policy": True,
-                           "is_visible": False, "default": ''}}}
+                           "is_visible": False, "default": ''},
+        "instance_node_id": {"allow_post": True, "allow_put": False,
+                             "default": '', "is_visible": False},
+    }
+}
 
 
 class Ports_quark(extensions.ExtensionDescriptor):

--- a/quark/drivers/base.py
+++ b/quark/drivers/base.py
@@ -36,6 +36,12 @@ class BaseDriver(object):
     def get_connection(self):
         LOG.info("get_connection")
 
+    def select_ipam_strategy(self, network_id, network_strategy, **kwargs):
+        LOG.info("Selecting IPAM strategy for network_id:%s "
+                 "network_strategy:%s" % (network_id, network_strategy))
+        LOG.info("Selected IPAM strategy: %s" % (network_strategy))
+        return network_strategy
+
     def create_network(self, context, network_name, tags=None,
                        network_id=None, **kwargs):
         LOG.info("create_network %s %s %s" % (context, network_name,

--- a/quark/drivers/ironic_driver.py
+++ b/quark/drivers/ironic_driver.py
@@ -1,0 +1,542 @@
+# Copyright 2013 Openstack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""
+Ironic agent driver for Quark.
+"""
+import netaddr
+
+from neutron.common import exceptions
+
+from oslo_config import cfg
+from oslo_log import log as logging
+from oslo_utils import importutils
+
+from quark.drivers import base
+from quark import utils
+
+import json
+
+from quark import network_strategy
+
+STRATEGY = network_strategy.STRATEGY
+
+LOG = logging.getLogger(__name__)
+
+CONF = cfg.CONF
+
+IRONIC_IPAM_STRATEGIES = {
+    "provider": {
+        "default": "IRONIC_ANY",
+        "overrides": {
+            "BOTH_REQUIRED": "IRONIC_BOTH_REQUIRED",
+            "BOTH": "IRONIC_BOTH",
+            "ANY": "IRONIC_ANY"
+        }
+    },
+    "tenant": {
+        "overrides": {}
+    }
+}
+
+ironic_opts = [
+    # client connection info
+    cfg.StrOpt("ironic_client", default="neutronclient.v2_0.client.Client",
+               help=("Class of the client used to communicate with the "
+                     "Ironic agent")),
+    cfg.StrOpt('endpoint_url',
+               default='http://127.0.0.1:9697',
+               help='URL for connecting to neutron'),
+    cfg.IntOpt('timeout',
+               default=30,
+               help='Timeout value for connecting to neutron in seconds.'),
+    cfg.BoolOpt('insecure',
+                default=False,
+                help='If set, ignore any SSL validation issues'),
+    cfg.StrOpt('ca_cert',
+               help=('Location of CA certificates file to use for '
+                     'neutron client requests.')),
+    cfg.StrOpt('password',
+               help='Password for connecting to neutron.', secret=True),
+    cfg.StrOpt('tenant_name',
+               help='Tenant name for connecting to neutron.'),
+    cfg.StrOpt('tenant_id',
+               help='Tenant id for connecting to neutron.'),
+    cfg.StrOpt('auth_url',
+               default='http://localhost:5000/v2.0',
+               help='Authorization URL for connecting to neutron.'),
+    cfg.StrOpt('auth_strategy',
+               default='keystone',
+               help='Authorization strategy for connecting to neutron.'),
+
+    # client retry options
+    cfg.IntOpt("operation_retries",
+               default=3,
+               help="Number of times to attempt client operations."),
+    cfg.IntOpt("operation_delay",
+               default=0,
+               help="Base seconds to wait between client attempts."),
+    cfg.IntOpt("operation_backoff",
+               default=0,
+               help="Base seconds for client exponential backoff"),
+
+    # conf options
+    cfg.StrOpt("ironic_ipam_strategies",
+               default=json.dumps(IRONIC_IPAM_STRATEGIES),
+               help="Default IPAM strategies and overrides for this driver")
+]
+
+CONF.register_opts(ironic_opts, "IRONIC")
+
+
+class FakeIronicClient(object):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def create_port(self, *args, **kwargs):
+        return {"port": {"vlan_id": 500, "id": "fake_uuid"}}
+
+    def delete_port(self, *args, **kwargs):
+        return
+
+
+class IronicException(exceptions.NeutronException):
+    message = "ironic driver error: %(msg)s"
+
+
+class IronicDriver(base.BaseDriver):
+    def __init__(self):
+        self._client = None
+        self._ipam_strategies = None
+        super(IronicDriver, self).__init__()
+
+    @classmethod
+    def get_name(cls):
+        return "IRONIC"
+
+    def load_config(self):
+        LOG.info("Loading Ironic settings.")
+        self._client_cls = importutils.import_class(CONF.IRONIC.ironic_client)
+        self._client = self._get_client()
+        self._ipam_strategies = self._parse_ironic_ipam_strategies()
+        LOG.info("Ironic Driver config loaded. Client: %s"
+                 % (CONF.IRONIC.endpoint_url))
+
+    def _get_client(self):
+
+        params = {
+            'endpoint_url': CONF.IRONIC.endpoint_url,
+            'timeout': CONF.IRONIC.timeout,
+            'insecure': CONF.IRONIC.insecure,
+            'ca_cert': CONF.IRONIC.ca_cert,
+            'auth_strategy': CONF.IRONIC.auth_strategy,
+            'tenant_name': CONF.IRONIC.tenant_name,
+            'tenant_id': CONF.IRONIC.tenant_id,
+            'password': CONF.IRONIC.password
+        }
+        return self._client_cls(**params)
+
+    def _parse_ironic_ipam_strategies(self):
+        strategies = json.loads(CONF.IRONIC.ironic_ipam_strategies)
+
+        for net_type in ['provider', 'tenant']:
+
+            strategy = strategies.get(net_type, {})
+            default = strategy.get("default")
+
+            # provider nets must specify a default IPAM strategy
+            if net_type == 'provider':
+                if not default:
+                    raise Exception("ironic_ipam_strategies must have a "
+                                    "default 'provider' strategy.")
+
+        return strategies
+
+    def select_ipam_strategy(self, network_id, network_strategy, **kwargs):
+        """Return relevant IPAM strategy name.
+
+        :param network_id: neutron network id.
+        :param network_strategy: default strategy for the network.
+
+        NOTE(morgabra) This feels like a hack but I can't think of a better
+        idea. The root problem is we can now attach ports to networks with
+        a different backend driver/ipam strategy than the network speficies.
+
+        We handle the the backend driver part with allowing network_plugin to
+        be specified for port objects. This works pretty well because nova or
+        whatever knows when we are hooking up an Ironic node so it can pass
+        along that key during port_create().
+
+        IPAM is a little trickier, especially in Ironic's case, because we
+        *must* use a specific IPAM for provider networks. There isn't really
+        much of an option other than involve the backend driver when selecting
+        the IPAM strategy.
+        """
+        LOG.info("Selecting IPAM strategy for network_id:%s "
+                 "network_strategy:%s" % (network_id, network_strategy))
+
+        net_type = "tenant"
+        if STRATEGY.is_provider_network(network_id):
+            net_type = "provider"
+
+        strategy = self._ipam_strategies.get(net_type, {})
+        default = strategy.get("default")
+        overrides = strategy.get("overrides", {})
+
+        # If we override a particular strategy explicitly, we use it.
+        if network_strategy in overrides:
+            LOG.info("Selected overridden IPAM strategy: %s"
+                     % (overrides[network_strategy]))
+            return overrides[network_strategy]
+
+        # Otherwise, we are free to use an explicit default.
+        if default:
+            LOG.info("Selected default IPAM strategy for tenant "
+                     "network: %s" % (default))
+            return default
+
+        # Fallback to the network-specified IPAM strategy
+        LOG.info("Selected network strategy for tenant "
+                 "network: %s" % (network_strategy))
+        return network_strategy
+
+    def _make_subnet_dict(self, subnet):
+
+        dns_nameservers = [str(netaddr.IPAddress(dns["ip"]))
+                           for dns in subnet.get("dns_nameservers")]
+
+        host_routes = [{"destination": r["cidr"],
+                        "nexthop": r["gateway"]} for r in subnet["routes"]]
+
+        res = {
+            "id": subnet.get("id"),
+            "name": subnet.get("name"),
+            "tenant_id": subnet.get("tenant_id"),
+            "dns_nameservers": dns_nameservers,
+            "host_routes": host_routes,
+            "cidr": subnet.get("cidr"),
+            "gateway_ip": subnet.get("gateway_ip")
+        }
+
+        return res
+
+    def _make_fixed_ip_dict(self, context, address):
+        return {"subnet": self._make_subnet_dict(address["subnet"]),
+                "ip_address": address["address_readable"]}
+
+    @utils.retry_loop(CONF.IRONIC.operation_retries,
+                      delay=CONF.IRONIC.operation_delay,
+                      backoff=CONF.IRONIC.operation_backoff)
+    def _create_port(self, context, body):
+        try:
+            return self._client.create_port(body={"port": body})
+        except Exception as e:
+            msg = "failed to create downstream port. Exception: %s" % (str(e))
+            LOG.exception(msg)
+            raise
+
+    def _get_base_network_info(self, context, network_id, base_net_driver):
+        """Return a dict of extra network information.
+
+        :param context: neutron request context.
+        :param network_id: neturon network id.
+        :param net_driver: network driver associated with network_id.
+        :raises IronicException: Any unexpected data fetching failures will
+            be logged and IronicException raised.
+
+        This driver can attach to networks managed by other drivers. We may
+        need some information from these drivers, or otherwise inform
+        downstream about the type of network we are attaching to. We can
+        make these decisions here.
+        """
+        driver_name = base_net_driver.get_name()
+        net_info = {"network_type": driver_name}
+        LOG.debug('_get_base_network_info: %s %s'
+                  % (driver_name, network_id))
+
+        # If the driver is NVP, we need to look up the lswitch id we should
+        # be attaching to.
+        if driver_name == 'NVP':
+            LOG.debug('looking up lswitch ids for network %s'
+                      % (network_id))
+            lswitch_ids = base_net_driver.get_lswitch_ids_for_network(
+                context, network_id)
+
+            if not lswitch_ids or len(lswitch_ids) > 1:
+                msg = ('lswitch id lookup failed, %s ids found.'
+                       % (len(lswitch_ids)))
+                LOG.error(msg)
+                raise IronicException(msg)
+
+            lswitch_id = lswitch_ids.pop()
+            LOG.info('found lswitch for network %s: %s'
+                     % (network_id, lswitch_id))
+            net_info['lswitch_id'] = lswitch_id
+
+        LOG.debug('_get_base_network_info finished: %s %s %s'
+                  % (driver_name, network_id, net_info))
+        return net_info
+
+    def create_port(self, context, network_id, port_id, **kwargs):
+        """Create a port.
+
+        :param context: neutron api request context.
+        :param network_id: neutron network id.
+        :param port_id: neutron port id.
+        :param kwargs:
+            required keys - device_id: neutron port device_id (instance_id)
+                            instance_node_id: nova hypervisor host id
+                            mac_address: neutron port mac address
+                            base_net_driver: the base network driver
+            optional keys - addresses: list of allocated IPAddress models
+                            security_groups: list of associated security groups
+        :raises IronicException: If the client is unable to create the
+            downstream port for any reason, the exception will be logged
+            and IronicException raised.
+        """
+        LOG.info("create_port %s %s %s" % (context.tenant_id, network_id,
+                                           port_id))
+
+        # sanity check
+        if not kwargs.get('base_net_driver'):
+            raise IronicException(msg='base_net_driver required.')
+        base_net_driver = kwargs['base_net_driver']
+
+        if not kwargs.get('device_id'):
+            raise IronicException(msg='device_id required.')
+        device_id = kwargs['device_id']
+
+        if not kwargs.get('instance_node_id'):
+            raise IronicException(msg='instance_node_id required.')
+        instance_node_id = kwargs['instance_node_id']
+
+        if not kwargs.get('mac_address'):
+            raise IronicException(msg='mac_address is required.')
+        mac_address = str(netaddr.EUI(kwargs["mac_address"]["address"]))
+        mac_address = mac_address.replace('-', ':')
+
+        # TODO(morgabra): Change this when we enable security groups.
+        if kwargs.get('security_groups'):
+            msg = 'ironic driver does not support security group operations.'
+            raise IronicException(msg=msg)
+
+        # unroll the given address models into a fixed_ips list we can
+        # pass downstream
+        fixed_ips = []
+        addresses = kwargs.get('addresses')
+        if not isinstance(addresses, list):
+            addresses = [addresses]
+        for address in addresses:
+            fixed_ips.append(self._make_fixed_ip_dict(context, address))
+
+        body = {
+            "id": port_id,
+            "network_id": network_id,
+            "device_id": device_id,
+            "device_owner": kwargs.get('device_owner', ''),
+            "tenant_id": context.tenant_id or "quark",
+            "mac_address": mac_address,
+            "fixed_ips": fixed_ips,
+            "switch:hardware_id": instance_node_id,
+            "dynamic_network": not STRATEGY.is_provider_network(network_id)
+        }
+
+        net_info = self._get_base_network_info(
+            context, network_id, base_net_driver)
+        body.update(net_info)
+
+        try:
+            LOG.info("creating downstream port: %s" % (body))
+            port = self._create_port(context, body)
+            LOG.info("created downstream port: %s" % (port))
+            return {"uuid": port['port']['id'],
+                    "vlan_id": port['port']['vlan_id']}
+        except Exception as e:
+            msg = "failed to create downstream port. Exception: %s" % (e)
+            raise IronicException(msg=msg)
+
+    def update_port(self, context, port_id, **kwargs):
+        """Update a port.
+
+        :param context: neutron api request context.
+        :param port_id: neutron port id.
+        :param kwargs: optional kwargs.
+        :raises IronicException: If the client is unable to update the
+            downstream port for any reason, the exception will be logged
+            and IronicException raised.
+
+        TODO(morgabra) It does not really make sense in the context of Ironic
+        to allow updating ports. fixed_ips and mac_address are burned in the
+        configdrive on the host, and we otherwise cannot migrate a port between
+        instances. Eventually we will need to support security groups, but for
+        now it's a no-op on port data changes, and we need to rely on the
+        API/Nova to not allow updating data on active ports.
+        """
+        LOG.info("update_port %s %s" % (context.tenant_id, port_id))
+
+        # TODO(morgabra): Change this when we enable security groups.
+        if kwargs.get("security_groups"):
+            msg = 'ironic driver does not support security group operations.'
+            raise IronicException(msg=msg)
+
+        return {"uuid": port_id}
+
+    @utils.retry_loop(CONF.IRONIC.operation_retries,
+                      delay=CONF.IRONIC.operation_delay,
+                      backoff=CONF.IRONIC.operation_backoff)
+    def _delete_port(self, context, port_id):
+        try:
+            return self._client.delete_port(port_id)
+        except Exception as e:
+            # This doesn't get wrapped by the client unfortunately.
+            if "404 not found" in str(e).lower():
+                LOG.error("port %s not found downstream. ignoring delete."
+                          % (port_id))
+                return
+
+            msg = ("failed to delete downstream port. "
+                   "exception: %s" % (e))
+            LOG.exception(msg)
+            raise
+
+    def delete_port(self, context, port_id, **kwargs):
+        """Delete a port.
+
+        :param context: neutron api request context.
+        :param port_id: neutron port id.
+        :param kwargs: optional kwargs.
+        :raises IronicException: If the client is unable to delete the
+            downstream port for any reason, the exception will be logged
+            and IronicException raised.
+        """
+        LOG.info("delete_port %s %s" % (context.tenant_id, port_id))
+        try:
+            self._delete_port(context, port_id)
+            LOG.info("deleted downstream port: %s" % (port_id))
+        except Exception:
+            LOG.error("failed deleting downstream port, it is now "
+                      "orphaned! port_id: %s" % (port_id))
+
+    def diag_port(self, context, port_id, **kwargs):
+        """Diagnose a port.
+
+        :param context: neutron api request context.
+        :param port_id: neutron port id.
+        :param kwargs: optional kwargs.
+        :raises IronicException: If the client is unable to fetch the
+            downstream port for any reason, the exception will be
+            logged and IronicException raised.
+        """
+        LOG.info("diag_port %s" % port_id)
+        try:
+            port = self._client.show_port(port_id)
+        except Exception as e:
+            msg = "failed fetching downstream port: %s" % (str(e))
+            LOG.exception(msg)
+            raise IronicException(msg=msg)
+        return {"downstream_port": port}
+
+    def create_network(self, *args, **kwargs):
+        """Create a network.
+
+        :raises NotImplementedError: This driver does not manage networks.
+
+        NOTE: This is a no-op in the base driver, but this raises here as to
+        explicitly disallow network operations in case of a misconfiguration.
+        """
+        raise NotImplementedError('ironic driver does not support '
+                                  'network operations.')
+
+    def delete_network(self, *args, **kwargs):
+        """Delete a network.
+
+        :raises NotImplementedError: This driver does not manage networks.
+
+        NOTE: This is a no-op in the base driver, but this raises here as to
+        explicitly disallow network operations in case of a misconfiguration.
+        """
+        raise NotImplementedError('ironic driver does not support '
+                                  'network operations.')
+
+    def diag_network(self, *args, **kwargs):
+        """Diagnose a network.
+
+        :raises NotImplementedError: This driver does not manage networks.
+
+        NOTE: This is a no-op in the base driver, but this raises here as to
+        explicitly disallow network operations in case of a misconfiguration.
+        """
+        raise NotImplementedError('ironic driver does not support '
+                                  'network operations.')
+
+    def create_security_group(self, context, group_name, **group):
+        """Create a security group.
+
+        :raises NotImplementedError: This driver does not implement security
+                                     groups.
+
+        NOTE: Security groups will be supported in the future, but for now
+        they are explicitly disallowed.
+        """
+        raise NotImplementedError('ironic driver does not support '
+                                  'security group operations.')
+
+    def delete_security_group(self, context, group_id, **kwargs):
+        """Delete a security group.
+
+        :raises NotImplementedError: This driver does not implement security
+                                     groups.
+
+        NOTE: Security groups will be supported in the future, but for now
+        they are explicitly disallowed.
+        """
+        raise NotImplementedError('ironic driver does not support '
+                                  'security group operations.')
+
+    def update_security_group(self, context, group_id, **group):
+        """Update a security group.
+
+        :raises NotImplementedError: This driver does not implement security
+                                     groups.
+
+        NOTE: Security groups will be supported in the future, but for now
+        they are explicitly disallowed.
+        """
+        raise NotImplementedError('ironic driver does not support '
+                                  'security group operations.')
+
+    def create_security_group_rule(self, context, group_id, rule):
+        """Create a security group rule.
+
+        :raises NotImplementedError: This driver does not implement security
+                                     groups.
+
+        NOTE: Security groups will be supported in the future, but for now
+        they are explicitly disallowed.
+        """
+        raise NotImplementedError('ironic driver does not support '
+                                  'security group operations.')
+
+    def delete_security_group_rule(self, context, group_id, rule):
+        """Delete a security group rule.
+
+        :raises NotImplementedError: This driver does not implement security
+                                     groups.
+
+        NOTE: Security groups will be supported in the future, but for now
+        they are explicitly disallowed.
+        """
+        raise NotImplementedError('ironic driver does not support '
+                                  'security group operations.')

--- a/quark/drivers/nvp_driver.py
+++ b/quark/drivers/nvp_driver.py
@@ -630,6 +630,16 @@ class NVPDriver(base.BaseDriver):
                 LOG.exception("Unexpected return from NVP: %s" % res)
                 raise
 
+    def get_lswitch_ids_for_network(self, context, network_id):
+        """Public interface for fetching lswitch ids for a given network.
+
+        NOTE(morgabra) This is here because calling private methods
+        from outside the class feels wrong, and we need to be able to
+        fetch lswitch ids for use in other drivers.
+        """
+        lswitches = self._lswitches_for_network(context, network_id).results()
+        return [s['uuid'] for s in lswitches["results"]]
+
     def _lswitches_for_network(self, context, network_id):
         with self.get_connection() as connection:
             query = connection.lswitch().query()

--- a/quark/drivers/optimized_nvp_driver.py
+++ b/quark/drivers/optimized_nvp_driver.py
@@ -226,6 +226,16 @@ class OptimizedNVPDriver(NVPDriver):
         context.session.add(new_switch)
         return new_switch
 
+    def get_lswitch_ids_for_network(self, context, network_id):
+        """Public interface for fetching lswitch ids for a given network.
+
+        NOTE(morgabra) This is here because calling private methods
+        from outside the class feels wrong, and we need to be able to
+        fetch lswitch ids for use in other drivers.
+        """
+        lswitches = self._lswitches_for_network(context, network_id)
+        return [s['nvp_id'] for s in lswitches]
+
     def _lswitches_for_network(self, context, network_id):
         switches = context.session.query(LSwitch).filter(
             LSwitch.network_id == network_id).all()

--- a/quark/drivers/unmanaged.py
+++ b/quark/drivers/unmanaged.py
@@ -17,7 +17,6 @@ from oslo_log import log as logging
 
 from quark.drivers import base
 from quark.drivers import security_groups as sg_driver
-
 from quark import network_strategy
 
 

--- a/quark/drivers/unmanaged.py
+++ b/quark/drivers/unmanaged.py
@@ -15,7 +15,9 @@
 
 from oslo_log import log as logging
 
+from quark.drivers import base
 from quark.drivers import security_groups as sg_driver
+
 from quark import network_strategy
 
 
@@ -23,7 +25,7 @@ STRATEGY = network_strategy.STRATEGY
 LOG = logging.getLogger(__name__)
 
 
-class UnmanagedDriver(object):
+class UnmanagedDriver(base.BaseDriver):
     """Unmanaged network driver.
 
     Returns a bridge...

--- a/quark/ipam.py
+++ b/quark/ipam.py
@@ -999,7 +999,7 @@ class IronicIpam(QuarkIpam):
     """IPAM base class for the Ironic driver.
 
     The idea here is that there are many small subnets created for a
-    particular segment for a provider network. And the Ironic IPAM
+    particular segment for a provider network. The Ironic IPAM
     family selects unused ones, and only allows a single allocation
     per subnet.
     """

--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -213,7 +213,6 @@ def _make_port_address_dict(ip, port, fields=None):
     subnet_id = ip.get("subnet_id")
     net_id = ip.get("network_id")
 
-    subnet_id = ip.get("subnet_id")
     show_provider_subnet_ids = CONF.QUARK.show_provider_subnet_ids
     if STRATEGY.is_provider_network(net_id) and show_provider_subnet_ids:
             subnet_id = STRATEGY.get_provider_subnet_id(

--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -44,6 +44,11 @@ quark_view_opts = [
                 default=True,
                 help=_('Controls whether or not to show ip_policy_id for'
                        'subnets')),
+    cfg.BoolOpt('show_provider_subnet_ids',
+                default=True,
+                help=_('Controls whether or not to show the provider subnet '
+                       'id specified in the network strategy or use the '
+                       'real id.')),
 ]
 
 CONF.register_opts(quark_view_opts, "QUARK")
@@ -207,8 +212,12 @@ def _make_port_address_dict(ip, port, fields=None):
     enabled = ip.enabled_for_port(port)
     subnet_id = ip.get("subnet_id")
     net_id = ip.get("network_id")
-    if STRATEGY.is_provider_network(net_id):
-        subnet_id = STRATEGY.get_provider_subnet_id(net_id, ip["version"])
+
+    subnet_id = ip.get("subnet_id")
+    show_provider_subnet_ids = CONF.QUARK.show_provider_subnet_ids
+    if STRATEGY.is_provider_network(net_id) and show_provider_subnet_ids:
+            subnet_id = STRATEGY.get_provider_subnet_id(
+                net_id, ip["version"])
 
     ip_addr = {"subnet_id": subnet_id,
                "ip_address": ip.formatted(),

--- a/quark/tests/test_base_driver.py
+++ b/quark/tests/test_base_driver.py
@@ -28,6 +28,10 @@ class TestBaseDriver(test_base.TestBase):
     def test_get_connection(self):
         self.driver.get_connection()
 
+    def test_select_ipam_strategy(self):
+        strategy = self.driver.select_ipam_strategy(1, "ANY")
+        self.assertEqual(strategy, "ANY")
+
     def test_create_network(self):
         self.driver.create_network(context=self.context, network_name="public")
 

--- a/quark/tests/test_ironic_driver.py
+++ b/quark/tests/test_ironic_driver.py
@@ -1,0 +1,633 @@
+# Copyright 2013 Openstack Foundation
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+#  under the License.
+
+import contextlib
+
+import netaddr
+
+import json
+
+import mock
+from oslo_config import cfg
+
+import quark.drivers.ironic_driver
+from quark import network_strategy
+from quark.tests import test_base
+
+
+class TestIronicDriverBase(test_base.TestBase):
+
+    def setUp(self):
+        super(TestIronicDriverBase, self).setUp()
+
+        net_strategy = {
+            "1": {
+                "bridge": "publicnet",
+                "subnets": {"4": "1", "6": "2"}
+            },
+            "2": {
+                "bridge": "publicnet",
+                "subnets": {"3": "1", "6": "4"}
+            }
+        }
+        strategy = json.dumps(net_strategy)
+        quark.drivers.ironic_driver.STRATEGY = network_strategy.JSONStrategy(
+            strategy)
+        cfg.CONF.set_override("default_net_strategy", strategy,
+                              "QUARK")
+
+        cfg.CONF.set_override("operation_delay", 0,
+                              "IRONIC")
+        cfg.CONF.set_override("operation_backoff", 0,
+                              "IRONIC")
+
+    @contextlib.contextmanager
+    def _stubs(self, create_port=None, delete_port=None):
+        importer, client, create, delete = self._create_client(
+            create_port, delete_port)
+        driver = quark.drivers.ironic_driver.IronicDriver()
+        yield driver, client, create, delete
+
+    def _create_client(self, create_port=None, delete_port=None):
+        patcher = mock.patch('quark.drivers.ironic_driver.importutils')
+        importer_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        client_mock = mock.Mock()
+        importer_mock.import_class.return_value = client_mock
+
+        create_port_mock = client_mock.return_value.create_port
+        if not create_port:
+            create_port = [{"port": {"vlan_id": 500, "id": "portid"}}]
+        create_port_mock.side_effect = create_port
+
+        delete_port_mock = client_mock.return_value.delete_port
+        if delete_port is None:
+            delete_port = [None]
+        delete_port_mock.side_effect = delete_port
+        return importer_mock, client_mock, create_port_mock, delete_port_mock
+
+    def _create_address(self, cidr, default_route=True):
+        cidr = netaddr.IPNetwork(cidr)
+
+        gateway_ip = str(netaddr.IPAddress(cidr.first + 1))
+        host_ip = str(netaddr.IPAddress(cidr.first + 2))
+
+        dns = [{"ip": "8.8.8.8"}, {"ip": "8.8.4.4"}]
+
+        routes = [{"cidr": "earth", "gateway": gateway_ip},
+                  {"cidr": "moon", "gateway": gateway_ip}]
+
+        address = {}
+        address["address_readable"] = host_ip
+
+        subnet = {
+            "id": "subnet_%s" % str(cidr),
+            "name": "subnet_name",
+            "tenant_id": "fake",
+            "dns_nameservers": dns,
+            "routes": routes if not default_route else [],
+            "gateway_ip": gateway_ip if default_route else None,
+            "cidr": str(cidr)
+        }
+        address["subnet"] = subnet
+        return address
+
+    def _create_base_net_driver(self, driver_type):
+        driver = mock.Mock()
+        driver.get_lswitch_ids_for_network.return_value = ["lswitch1"]
+        driver.get_name.return_value = driver_type
+        return driver
+
+
+class TestIronicDriver(TestIronicDriverBase):
+
+    def test_import_client_class(self):
+        importer, _, _, _ = self._create_client()
+        quark.drivers.ironic_driver.IronicDriver()
+        importer.import_class.assert_called_once_with(
+            cfg.CONF.IRONIC.ironic_client)
+
+    def test_client_is_instantiated(self):
+        with self._stubs() as (driver, client, _, _):
+            params = {
+                'endpoint_url': cfg.CONF.IRONIC.endpoint_url,
+                'timeout': cfg.CONF.IRONIC.timeout,
+                'insecure': cfg.CONF.IRONIC.insecure,
+                'ca_cert': cfg.CONF.IRONIC.ca_cert,
+                'auth_strategy': cfg.CONF.IRONIC.auth_strategy,
+                'tenant_name': cfg.CONF.IRONIC.tenant_name,
+                'tenant_id': cfg.CONF.IRONIC.tenant_id,
+                'password': cfg.CONF.IRONIC.password
+            }
+            client.assert_called_once_with(**params)
+
+
+class TestIronicDriverIPAMStrategies(TestIronicDriverBase):
+
+    def test_ipam_strategies(self):
+        with self._stubs() as (driver, client, _, _):
+            self.assertEqual(
+                driver._ipam_strategies,
+                json.loads(cfg.CONF.IRONIC.ironic_ipam_strategies))
+
+    def test_invalid_ipam_strategy_raises(self):
+        cfg.CONF.set_override('ironic_ipam_strategies',
+                              '{}',
+                              'IRONIC')
+        self.addCleanup(cfg.CONF.clear_override,
+                        'ironic_ipam_strategies',
+                        'IRONIC')
+        self.assertRaises(quark.drivers.ironic_driver.IronicDriver)
+
+    def test_ipam_strategy_provider_overrides(self):
+        with self._stubs() as (driver, _, _, _):
+            strategy = driver.select_ipam_strategy("1", "BOTH")
+            self.assertEqual(strategy, "IRONIC_BOTH")
+
+    def test_ipam_strategy_provider_returns_default(self):
+        with self._stubs() as (driver, _, _, _):
+            strategy = driver.select_ipam_strategy("1", "WTF")
+            self.assertEqual(strategy, "IRONIC_ANY")
+
+    def test_ipam_strategy_tenant_returns_network_strategy(self):
+        with self._stubs() as (driver, _, _, _):
+            strategy = driver.select_ipam_strategy("3", "WTF")
+            self.assertEqual(strategy, "WTF")
+
+
+class TestIronicDriverCreatePort(TestIronicDriverBase):
+
+    def test_create_port(self):
+        create_response = {
+            "port": {
+                "id": "port1",
+                "vlan_id": 120
+            }
+        }
+        with self._stubs(create_port=[create_response]) as (driver, _,
+                                                            create, _):
+
+            network_id = "net1"
+            port_id = "port1"
+
+            # mock of the default driver class for the network
+            base_net_driver = self._create_base_net_driver(
+                "UNMANAGED")
+
+            kwargs = {
+                "device_id": "device1",
+                "instance_node_id": "nodeid1",
+                "mac_address": {"address": 1},
+                "base_net_driver": base_net_driver,
+                "addresses": [],
+                "security_groups": [],
+            }
+            res = driver.create_port(
+                self.context, network_id, port_id,
+                **kwargs)
+
+            expected_call = {
+                'port': {
+                    'switch:hardware_id': kwargs["instance_node_id"],
+                    'device_owner': '',
+                    'network_type': "UNMANAGED",
+                    'mac_address': '00:00:00:00:00:01',
+                    'network_id': network_id,
+                    'tenant_id': self.context.tenant_id,
+                    'dynamic_network': True,
+                    'fixed_ips': [],
+                    'id': port_id,
+                    'device_id': kwargs["device_id"]
+                }
+            }
+
+            self.assertEqual(
+                res, {"uuid": create_response["port"]["id"],
+                      "vlan_id": create_response["port"]["vlan_id"]})
+            create.assert_called_once_with(body=expected_call)
+
+    def test_create_port_includes_lswitch_ids(self):
+        create_response = {
+            "port": {
+                "id": "port1",
+                "vlan_id": 120
+            }
+        }
+        with self._stubs(create_port=[create_response]) as (driver, _,
+                                                            create, _):
+
+            network_id = "net1"
+            port_id = "port1"
+
+            # mock of the default driver class for the network
+            base_net_driver = self._create_base_net_driver(
+                "NVP")
+
+            kwargs = {
+                "device_id": "device1",
+                "instance_node_id": "nodeid1",
+                "mac_address": {"address": 1},
+                "base_net_driver": base_net_driver,
+                "addresses": [],
+                "security_groups": [],
+            }
+            res = driver.create_port(
+                self.context, network_id, port_id,
+                **kwargs)
+
+            expected_call = {
+                'port': {
+                    'switch:hardware_id': kwargs["instance_node_id"],
+                    'device_owner': '',
+                    'network_type': "NVP",
+                    'mac_address': '00:00:00:00:00:01',
+                    'network_id': network_id,
+                    'tenant_id': self.context.tenant_id,
+                    'lswitch_id': 'lswitch1',
+                    'dynamic_network': True,
+                    'fixed_ips': [],
+                    'id': port_id,
+                    'device_id': kwargs["device_id"]
+                }
+            }
+
+            self.assertEqual(
+                res, {"uuid": create_response["port"]["id"],
+                      "vlan_id": create_response["port"]["vlan_id"]})
+            create.assert_called_once_with(body=expected_call)
+
+    def test_create_port_retries(self):
+        create_response = [
+            Exception("uhoh"),
+            {"port": {"id": "port1", "vlan_id": 120}}
+        ]
+        with self._stubs(create_port=create_response) as (driver, _,
+                                                          create, _):
+
+            network_id = "net1"
+            port_id = "port1"
+
+            # mock of the default driver class for the network
+            base_net_driver = self._create_base_net_driver(
+                "UNMANAGED")
+
+            kwargs = {
+                "device_id": "device1",
+                "instance_node_id": "nodeid1",
+                "mac_address": {"address": 1},
+                "base_net_driver": base_net_driver,
+                "addresses": [],
+                "security_groups": [],
+            }
+            res = driver.create_port(
+                self.context, network_id, port_id,
+                **kwargs)
+
+            expected_call = {
+                'port': {
+                    'switch:hardware_id': kwargs["instance_node_id"],
+                    'device_owner': '',
+                    'network_type': "UNMANAGED",
+                    'mac_address': '00:00:00:00:00:01',
+                    'network_id': network_id,
+                    'tenant_id': self.context.tenant_id,
+                    'dynamic_network': True,
+                    'fixed_ips': [],
+                    'id': port_id,
+                    'device_id': kwargs["device_id"]
+                }
+            }
+
+            self.assertEqual(
+                res,
+                {"uuid": create_response[1]["port"]["id"],
+                 "vlan_id": create_response[1]["port"]["vlan_id"]})
+
+            self.assertEqual(
+                create.call_args_list,
+                [mock.call(body=expected_call),
+                 mock.call(body=expected_call)])
+
+    def test_create_port_raises_after_retry_failures(self):
+        create_response = [
+            Exception("uhoh"),
+            Exception("uhoh"),
+            Exception("uhoh"),
+        ]
+        with self._stubs(create_port=create_response) as (driver, _,
+                                                          create, _):
+
+            network_id = "net1"
+            port_id = "port1"
+
+            # mock of the default driver class for the network
+            base_net_driver = self._create_base_net_driver(
+                "UNMANAGED")
+
+            kwargs = {
+                "device_id": "device1",
+                "instance_node_id": "nodeid1",
+                "mac_address": {"address": 1},
+                "base_net_driver": base_net_driver,
+                "addresses": [],
+                "security_groups": [],
+            }
+            self.assertRaises(
+                quark.drivers.ironic_driver.IronicException,
+                driver.create_port,
+                self.context, network_id, port_id, **kwargs)
+
+            expected_call = {
+                'port': {
+                    'switch:hardware_id': kwargs["instance_node_id"],
+                    'device_owner': '',
+                    'network_type': "UNMANAGED",
+                    'mac_address': '00:00:00:00:00:01',
+                    'network_id': network_id,
+                    'tenant_id': self.context.tenant_id,
+                    'dynamic_network': True,
+                    'fixed_ips': [],
+                    'id': port_id,
+                    'device_id': kwargs["device_id"]
+                }
+            }
+
+            self.assertEqual(create.call_count, 3)
+
+            self.assertEqual(
+                create.call_args_list,
+                [mock.call(body=expected_call),
+                 mock.call(body=expected_call),
+                 mock.call(body=expected_call)])
+
+    def test_create_port_raises_with_missing_required_kwargs(self):
+        with self._stubs() as (driver, _, create, _):
+
+            network_id = "net1"
+            port_id = "port1"
+
+            # mock of the default driver class for the network
+            base_net_driver = self._create_base_net_driver(
+                "UNMANAGED")
+
+            kwargs = {
+                "device_id": "device1",
+                "instance_node_id": "nodeid1",
+                "mac_address": {"address": 1},
+                "base_net_driver": base_net_driver,
+                "addresses": [],
+                "security_groups": [],
+            }
+
+            for kwarg in ["base_net_driver", "device_id",
+                          "instance_node_id", "mac_address"]:
+
+                val = kwargs.pop(kwarg)
+
+                self.assertRaises(
+                    quark.drivers.ironic_driver.IronicException,
+                    driver.create_port,
+                    self.context, network_id, port_id, **kwargs)
+
+                kwargs[kwarg] = val
+
+                create.assert_not_called()
+
+    def test_create_port_raises_with_security_groups(self):
+        with self._stubs() as (driver, _, create, _):
+
+            network_id = "net1"
+            port_id = "port1"
+
+            # mock of the default driver class for the network
+            base_net_driver = self._create_base_net_driver(
+                "UNMANAGED")
+
+            kwargs = {
+                "device_id": "device1",
+                "instance_node_id": "nodeid1",
+                "mac_address": {"address": 1},
+                "base_net_driver": base_net_driver,
+                "addresses": [],
+                "security_groups": ["foo"],
+            }
+
+            self.assertRaises(
+                quark.drivers.ironic_driver.IronicException,
+                driver.create_port,
+                self.context, network_id, port_id, **kwargs)
+
+            create.assert_not_called()
+
+    def test_create_port_with_fixed_ips(self):
+        create_response = {
+            "port": {
+                "id": "port1",
+                "vlan_id": 120
+            }
+        }
+        with self._stubs(create_port=[create_response]) as (driver, _,
+                                                            create, _):
+
+            network_id = "net1"
+            port_id = "port1"
+
+            # mock of the default driver class for the network
+            base_net_driver = self._create_base_net_driver(
+                "UNMANAGED")
+
+            kwargs = {
+                "device_id": "device1",
+                "instance_node_id": "nodeid1",
+                "mac_address": {"address": 1},
+                "base_net_driver": base_net_driver,
+                "addresses": [self._create_address("10.0.0.0/30"),
+                              self._create_address("10.0.0.5/30",
+                                                   default_route=False)],
+                "security_groups": [],
+            }
+            res = driver.create_port(
+                self.context, network_id, port_id,
+                **kwargs)
+
+            fixed_ips = [
+                {'subnet': {
+                    'name': 'subnet_name',
+                    'tenant_id': 'fake',
+                    'dns_nameservers': ['8.8.8.8', '8.8.4.4'],
+                    'host_routes': [],
+                    'gateway_ip': '10.0.0.1',
+                    'cidr': '10.0.0.0/30',
+                    'id': 'subnet_10.0.0.0/30'},
+                 'ip_address': '10.0.0.2'},
+                {'subnet': {
+                    'name': 'subnet_name',
+                    'tenant_id': 'fake',
+                    'dns_nameservers': ['8.8.8.8', '8.8.4.4'],
+                    'host_routes': [
+                        {'nexthop': '10.0.0.5',
+                         'destination': 'earth'},
+                        {'nexthop': '10.0.0.5',
+                         'destination': 'moon'}
+                    ],
+                    'gateway_ip': None,
+                    'cidr': '10.0.0.5/30',
+                    'id': 'subnet_10.0.0.5/30'},
+                 'ip_address': '10.0.0.6'}
+            ]
+
+            expected_call = {
+                'port': {
+                    'switch:hardware_id': kwargs["instance_node_id"],
+                    'device_owner': '',
+                    'network_type': "UNMANAGED",
+                    'mac_address': '00:00:00:00:00:01',
+                    'network_id': network_id,
+                    'tenant_id': self.context.tenant_id,
+                    'dynamic_network': True,
+                    'fixed_ips': fixed_ips,
+                    'id': port_id,
+                    'device_id': kwargs["device_id"]
+                }
+            }
+
+            self.assertEqual(
+                res, {"uuid": create_response["port"]["id"],
+                      "vlan_id": create_response["port"]["vlan_id"]})
+            create.assert_called_once_with(body=expected_call)
+
+
+class TestIronicDriverDeletePort(TestIronicDriverBase):
+
+    def test_delete_port(self):
+        with self._stubs(delete_port=[None]) as (driver, client,
+                                                 _, delete):
+            driver.delete_port(self.context, "foo")
+            delete.assert_called_once_with("foo")
+
+    def test_delete_port_retries(self):
+        delete_port = [Exception("uhoh"), None]
+        with self._stubs(delete_port=delete_port) as (driver,
+                                                      client, _,
+                                                      delete):
+            driver.delete_port(self.context, "foo")
+            self.assertEqual(delete.call_count, 2)
+            self.assertEqual(
+                delete.call_args_list,
+                [mock.call("foo"), mock.call("foo")])
+
+    def test_delete_port_fail_does_not_raise(self):
+        delete_port = [Exception("uhoh"),
+                       Exception("uhoh"),
+                       Exception("uhoh")]
+        with self._stubs(delete_port=delete_port) as (driver,
+                                                      client, _,
+                                                      delete):
+            driver.delete_port(self.context, "foo")
+            self.assertEqual(delete.call_count, 3)
+            self.assertEqual(
+                delete.call_args_list,
+                [mock.call("foo"), mock.call("foo"),
+                 mock.call("foo")])
+
+    def test_delete_port_ignores_404(self):
+        delete_port = [Exception("404 not found"), None]
+        with self._stubs(delete_port=delete_port) as (driver,
+                                                      client, _,
+                                                      delete):
+            driver.delete_port(self.context, "foo")
+            delete.assert_called_once_with("foo")
+
+
+class TestIronicDriverUpdatePort(TestIronicDriverBase):
+
+    def test_update_does_nothing(self):
+        with self._stubs() as (driver, client,
+                               _, delete):
+            res = driver.update_port(self.context, "foo", **{})
+            client.update_port.assert_not_called()
+            self.assertEqual(res, {"uuid": "foo"})
+
+    def test_update_with_sg_raises(self):
+        with self._stubs() as (driver, client,
+                               _, delete):
+            self.assertRaises(
+                quark.drivers.ironic_driver.IronicException,
+                driver.update_port,
+                self.context, "foo",
+                security_groups=["sg1"])
+
+
+class TestIronicDriverNetwork(TestIronicDriverBase):
+
+    def test_create_network_raises(self):
+        with self._stubs() as (driver, _, _, _):
+            self.assertRaises(
+                NotImplementedError,
+                driver.create_network,
+                1)
+
+    def test_delete_network_raises(self):
+        with self._stubs() as (driver, _, _, _):
+            self.assertRaises(
+                NotImplementedError,
+                driver.delete_network,
+                1)
+
+    def test_diag_network_raises(self):
+        with self._stubs() as (driver, _, _, _):
+            self.assertRaises(
+                NotImplementedError,
+                driver.diag_network,
+                1)
+
+
+class TestIronicDriverSecurityGroups(TestIronicDriverBase):
+
+    def test_create_security_group(self):
+        with self._stubs() as (driver, _, _, _):
+            self.assertRaises(
+                NotImplementedError,
+                driver.create_security_group,
+                self.context, "fake")
+
+    def test_delete_security_group(self):
+        with self._stubs() as (driver, _, _, _):
+            self.assertRaises(
+                NotImplementedError,
+                driver.delete_security_group,
+                self.context, "fake")
+
+    def test_update_security_group(self):
+        with self._stubs() as (driver, _, _, _):
+            self.assertRaises(
+                NotImplementedError,
+                driver.update_security_group,
+                self.context, "fake")
+
+    def test_create_security_group_rule(self):
+        with self._stubs() as (driver, _, _, _):
+            self.assertRaises(
+                NotImplementedError,
+                driver.create_security_group_rule,
+                self.context, "fake", "fake_rule")
+
+    def test_delete_security_group_rule(self):
+        with self._stubs() as (driver, _, _, _):
+            self.assertRaises(
+                NotImplementedError,
+                driver.delete_security_group_rule,
+                self.context, "fake", "fake_rule")

--- a/quark/tests/test_nvp_driver.py
+++ b/quark/tests/test_nvp_driver.py
@@ -384,6 +384,10 @@ class TestNVPDriverCreatePort(TestNVPDriver):
             get_net_dets.return_value = net_details
             yield connection
 
+    def test_select_ipam_strategy(self):
+        strategy = self.driver.select_ipam_strategy(1, "ANY")
+        self.assertEqual(strategy, "ANY")
+
     def test_create_port_switch_exists(self):
         with self._stubs(net_details=dict(foo=3)) as (connection):
             port = self.driver.create_port(self.context, self.net_id,
@@ -562,7 +566,8 @@ class TestNVPDriverLswitchesForNetwork(TestNVPDriver):
         with contextlib.nested(
             mock.patch("%s._connection" % self.d_pkg),
         ) as (conn,):
-            connection = self._create_connection(switch_count=1)
+            connection = self._create_connection(
+                has_switches=True, switch_count=1)
             conn.return_value = connection
             yield connection
 
@@ -574,6 +579,16 @@ class TestNVPDriverLswitchesForNetwork(TestNVPDriver):
             query_mock.tagscopes = mock.Mock()
             connection.query = mock.Mock(return_value=query_mock)
             self.driver._lswitches_for_network(self.context, "net_uuid")
+
+    def test_get_lswitch_ids_for_network(self):
+        with self._stubs() as connection:
+            query_mock = mock.Mock()
+            query_mock.tags = mock.Mock()
+            query_mock.tagscopes = mock.Mock()
+            connection.query = mock.Mock(return_value=query_mock)
+            lswitch_ids = self.driver.get_lswitch_ids_for_network(
+                self.context, "net_uuid")
+            self.assertEqual(lswitch_ids, ['abcd'])
 
 
 class TestSwitchCopying(TestNVPDriver):

--- a/quark/tests/test_optimized_nvp_driver.py
+++ b/quark/tests/test_optimized_nvp_driver.py
@@ -298,6 +298,10 @@ class TestOptimizedNVPDriverCreatePort(TestOptimizedNVPDriver):
             get_net_dets.return_value = dict(foo=3)
             yield connection, create_opt
 
+    def test_select_ipam_strategy(self):
+        strategy = self.driver.select_ipam_strategy(1, "ANY")
+        self.assertEqual(strategy, "ANY")
+
     def test_create_port_and_maxed_switch_spanning(self):
         '''Testing to ensure a switch is made when maxed.'''
         with self._stubs(maxed_ports=True) as (
@@ -578,6 +582,14 @@ class TestQueryMethods(TestOptimizedNVPDriver):
         with self._stubs() as query_return:
             self.driver._lswitches_for_network(self.context, 1)
             self.assertTrue(query_return.filter.called)
+
+    def test_get_lswitch_ids_for_network(self):
+        with self._stubs() as query_return:
+            query_result = query_return.filter.return_value.all
+            query_result.return_value = [{"nvp_id": "foo"}]
+            ids = self.driver.get_lswitch_ids_for_network(self.context, 1)
+            self.assertTrue(query_return.filter.called)
+            self.assertEqual(ids, ["foo"])
 
     def test_lswitch_from_port(self):
         with self._stubs() as query_return:

--- a/quark/tests/test_unmanaged_driver.py
+++ b/quark/tests/test_unmanaged_driver.py
@@ -42,6 +42,10 @@ class TestUnmanagedDriver(test_base.TestBase):
     def test_get_connection(self):
         self.driver.get_connection()
 
+    def test_select_ipam_strategy(self):
+        strategy = self.driver.select_ipam_strategy(1, "ANY")
+        self.assertEqual(strategy, "ANY")
+
     def test_create_network(self):
         self.driver.create_network(context=self.context,
                                    network_name="testwork")


### PR DESCRIPTION
This is unfortunately named, because really, it's a pure http proxy backend driver. I'm open to renaming everything to reflect that if you like. 

The idea here is to let quark be in charge of allocation of macs/ips, validating quotas, access control, lifecycle of the port, etc. Instead of calling to NSX or whatever on port create, it instead hits an arbitrary HTTP endpoint with the collected port data.

This supports an agent-like pattern, where the agent is free to manage the actual configuration necessary. This is pretty useful in a bare metal context, given that we have to tightly manage the lifecycle of the actual live configuration on the host, and most of that process is pretty unique to the service and didn't seem like it fit trying to shoehorn the whole thing into quark proper, or at least not at first.

This also adds an IPAM that is suitable for allocating single ips from groups of very small subnets, instead of multiple ips out of larger ones. (Think a bunch of /30s or something)

