### PR TITLE
Fail mysql functional tests quickly

### DIFF
--- a/quark/tests/functional/mysql/base.py
+++ b/quark/tests/functional/mysql/base.py
@@ -20,6 +20,14 @@ class MySqlBaseFunctionalTest(test_base.TestBase):
             sql_string,
             'database')
         cfg.CONF.set_override(
+            'max_retries',
+            1,
+            'database')
+        cfg.CONF.set_override(
+            'retry_interval',
+            0,
+            'database')
+        cfg.CONF.set_override(
             'connection_debug',
             '0',
             'database')


### PR DESCRIPTION
Without this patch, each mysql functional test takes 100 seconds to fail.
There are ~40 tests, so 4,000 seconds waiting to fail.

With this change, all tests will fail almost immediately, in a good way.

JIRA:NCP-1784