### PR TITLE
Fix SegmentAllocationRange queries for non-elevated context

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -42,6 +42,11 @@ CONF = cfg.CONF
 ONE = "one"
 ALL = "all"
 
+_NO_TENANT_MODELS = (
+    models.PortIpAssociation,
+    models.LockHolder,
+    models.SegmentAllocationRange)
+
 
 # NOTE(jkoelker) init event listener that will ensure id is filled in
 #                on object creation (prior to commit).
@@ -150,8 +155,7 @@ def _model_query(context, model, filters, fields=None):
         elif key == "tenant_id":
             if model == models.IPAddress:
                 model_filters.append(model.used_by_tenant_id.in_(value))
-            elif (model == models.PortIpAssociation or
-                  model == models.LockHolder):
+            elif model in _NO_TENANT_MODELS:
                 pass
             else:
                 model_filters.append(model.tenant_id.in_(value))

--- a/quark/tests/functional/plugin_modules/test_segment_allocation.py
+++ b/quark/tests/functional/plugin_modules/test_segment_allocation.py
@@ -195,6 +195,9 @@ class QuarkTestCreateSegmentAllocationRange(QuarkSegmentAllocationTest):
         # Find all ranges added in the db
         sa_range_models = db_api.segment_allocation_range_find(
             self.context, scope=db_api.ALL)
+        # ensure non-admins can fetch them as well
+        sa_range_models = db_api.segment_allocation_range_find(
+            self.old_context, scope=db_api.ALL)
 
         # Assert we actually added the range to the db with correct
         # values and returned the correct response.


### PR DESCRIPTION
Add SegmentAllocationRange to the list of models that do not
filter on tenant_id to avoid blowing up in _model_query.

This is queried when a network is created, so non-admin users need to be
able to read this table, which means tenant_id is injected into the
query. However, the SegmentAllocationRange model doesn't have a tenant_id,
so we need to avoid filtering on that.

JIRA:NCP-1804