### PR TITLE
Remove lockmode on mac count for dealloc failures

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -475,7 +475,7 @@ def mac_address_range_find_allocation_counts(context, address=None,
                                              use_forbidden_mac_range=False):
     count = sql_func.count(models.MacAddress.address)
     query = context.session.query(models.MacAddressRange,
-                                  count.label("count")).with_lockmode("update")
+                                  count.label("count"))
     query = query.outerjoin(models.MacAddress)
     query = query.group_by(models.MacAddressRange.id)
     query = query.order_by(desc(count))


### PR DESCRIPTION
Removes the lockmode on mac count query. This is an experimental fix
that needs to be tested before release or merge into master.

JIRA:NCP-1806