### PR TITLE
Fixed null value for the floating ip status

### DIFF
--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -338,5 +338,5 @@ def _make_floating_ip_dict(flip, port_id=None):
             "fixed_ip_address": None if not fixed_ip else fixed_ip.formatted(),
             "floating_ip_address": flip.formatted(),
             "tenant_id": flip.get("used_by_tenant_id"),
-            "status": flip.get("status"),
+            "status": "RESERVED" if not port_id else "ASSOCIATED",
             "port_id": port_id}


### PR DESCRIPTION
NCP-1689

Since we do not currently set or track the status of a flip (because the flip controllers do not have a callback to update the status) I modified the view to set the status to either RESERVED (if not associated with a port) or ASSOCIATED (if associated with a port).  