### PR TITLE
Deferred allocation pool cache

### DIFF
--- a/quark/db/models.py
+++ b/quark/db/models.py
@@ -316,7 +316,7 @@ class Subnet(BASEV2, models.HasId, IsHazTags):
     name = sa.Column(sa.String(255))
     network_id = sa.Column(sa.String(36), sa.ForeignKey('quark_networks.id'))
     _cidr = sa.Column(sa.String(64), nullable=False)
-    _allocation_pool_cache = sa.Column(sa.Text(), nullable=True)
+    _allocation_pool_cache = orm.deferred(sa.Column(sa.Text(), nullable=True))
     tenant_id = sa.Column(sa.String(255), index=True)
     segment_id = sa.Column(sa.String(255), index=True)
 

--- a/quark/tests/plugin_modules/test_subnets.py
+++ b/quark/tests/plugin_modules/test_subnets.py
@@ -1232,6 +1232,7 @@ class TestSubnetsQuotas(test_quark_plugin.TestQuarkPlugin):
             s["network"] = models.Network()
             s["network"]["created_at"] = s["created_at"]
             s["dns_nameservers"] = []
+            s["_allocation_pool_cache"] = None
             subnet = models.Subnet(**s)
             subnets.append(subnet)
         with contextlib.nested(


### PR DESCRIPTION
Defer hitting the database for the allocation pool cache until it
is actually accessed in code. This should lead to a performance
boost in some situations.

JIRA:NCP-1822