### PR TITLE
Redirect warnings

### DIFF
--- a/quark/tests/__init__.py
+++ b/quark/tests/__init__.py
@@ -1,0 +1,4 @@
+import logging
+
+
+logging.captureWarnings(True)


### PR DESCRIPTION
Make output of tox tests cleaner by redirecting warnings to logging, with the added benefit of logging warnings in production, in case the edge cases tox is picking up on are being encountered for-realsies.

JIRA:NCP-1834