### PR TITLE
Removed redundant call to deallocate the floating IP address

### DIFF
--- a/quark/plugin_modules/floating_ips.py
+++ b/quark/plugin_modules/floating_ips.py
@@ -271,11 +271,8 @@ def delete_floatingip(context, id):
         if flip.fixed_ip:
             flip = db_api.floating_ip_disassociate_fixed_ip(context, flip)
 
-        db_api.ip_address_deallocate(context, flip)
-
-        if flip.fixed_ip:
-            driver = registry.DRIVER_REGISTRY.get_driver()
-            driver.remove_floating_ip(flip)
+        driver = registry.DRIVER_REGISTRY.get_driver()
+        driver.remove_floating_ip(flip)
         context.session.commit()
     except Exception:
         context.session.rollback()


### PR DESCRIPTION
NCP-1847

Removed redundant calls to deallocate the ip address.  Once to IPAM, and the second to the data_api directly.