### PR TITLE
Changed the ips/id/ports key for new client bug

### DIFF
--- a/docs/shared_ips.raml
+++ b/docs/shared_ips.raml
@@ -188,7 +188,7 @@ traits:
                         body:
                             application/json:
                                 example: |
-                                    {"ports": [{"id": "dce3dca6-2cba-4e00-95e9-748587f94620", "service": "compute",
+                                    {"ip_addresses_ports": [{"id": "dce3dca6-2cba-4e00-95e9-748587f94620", "service": "compute",
                                     "device_id": "3b150725-cebb-492d-8286-9dbe80b54a87"}]}
                     404:
                         description: not found
@@ -202,7 +202,7 @@ traits:
                     body:
                         application/json:
                             example: |
-                                {"port": {"id": "dce3dca6-2cba-4e00-95e9-748587f94620", "service": "compute",
+                                {"ip_addresses_port": {"id": "dce3dca6-2cba-4e00-95e9-748587f94620", "service": "compute",
                                 "device_id": "3b150725-cebb-492d-8286-9dbe80b54a87"}}
                 put:
                     description: |
@@ -210,7 +210,7 @@ traits:
                     body:
                         application/json:
                             example: |
-                                {"port": {"service": "compute"}}
+                                {"ip_addresses_port": {"service": "compute"}}
                     responses:
                         200:
                             description: updated

--- a/quark/api/extensions/ip_addresses.py
+++ b/quark/api/extensions/ip_addresses.py
@@ -112,7 +112,7 @@ class IpAddressPortController(wsgi.Controller):
         fx = self._plugin.get_ports_for_ip_address
         try:
             ports = fx(context, ip_address_id, filters=filters, **request.GET)
-            return {"ports": ports}
+            return {"ip_addresses_ports": ports}
         except n_exc.NotFound as e:
             raise webob.exc.HTTPNotFound(e)
 
@@ -123,7 +123,7 @@ class IpAddressPortController(wsgi.Controller):
         context = request.context
         # TODO(jlh): need to ensure ip_address_id is used to filter port
         try:
-            return {"port":
+            return {"ip_addresses_port":
                     self._plugin.get_port_for_ip_address(context,
                                                          ip_address_id, id)}
         except n_exc.NotFound as e:
@@ -132,9 +132,8 @@ class IpAddressPortController(wsgi.Controller):
     def update(self, ip_address_id, request, id, body=None):
         body = self._deserialize(request.body, request.get_content_type())
         try:
-            return {"port": self._plugin.update_port_for_ip(request.context,
-                                                            ip_address_id,
-                                                            id, body)}
+            return {"ip_addresses_port": self._plugin.update_port_for_ip(
+                request.context, ip_address_id, id, body)}
         except n_exc.NotFound as e:
             raise webob.exc.HTTPNotFound(e)
         except n_exc.BadRequest as e:


### PR DESCRIPTION
JIRA:NCP-1840

New client from upstream doesn't like it when the resource key differs
from what is expected.

Conflicts:
	quark/api/extensions/ip_addresses.py