### PR TITLE
Just skips subnets that are None during ipam

### DIFF
--- a/quark/ipam.py
+++ b/quark/ipam.py
@@ -863,6 +863,8 @@ class QuarkIpam(object):
                                                              segment_id,
                                                              subnet_ids,
                                                              **filters):
+                if subnet is None:
+                    continue
                 ipnet = netaddr.IPNetwork(subnet["cidr"])
                 LOG.info("Trying subnet ID: {0} - CIDR: {1}".format(
                     subnet["id"], subnet["_cidr"]))


### PR DESCRIPTION
JIRA:NCP-1304

This is an incredibly rare and non-impacting situation. All it does is
add a single iteration to the loop and creates weird log messages. Since
it doesn't really do anything to add this continue I'm not going to
bother to create a test (since the desired effect is to do what it does
right now).

Again, this primarily will just try to make logging more clear in the
future.