### PR TITLE
remove use_master args in redis tool as the redis client now handles this.

### DIFF
--- a/quark/tests/tools/test_redis_sg_tool.py
+++ b/quark/tests/tools/test_redis_sg_tool.py
@@ -173,10 +173,10 @@ class QuarkRedisSgToolPurgeOrphans(QuarkRedisSgToolBase):
             cli = sg_client()
             cli.purge_orphans(dryrun=True)
 
-            get_conn.assert_called_with(use_master=False)
             connection_mock.vif_key.assert_any_call(1, 1)
             db_ports_groups.assert_called_with(ctxt_mock)
             connection_mock.delete_key.assert_not_called()
+            self.assertTrue(get_conn.call_count, 1)
 
     def test_purge_orphans(self):
         with self._stubs() as (get_conn, connection_mock, db_ports_groups,
@@ -185,7 +185,6 @@ class QuarkRedisSgToolPurgeOrphans(QuarkRedisSgToolBase):
             cli.purge_orphans(dryrun=False)
 
             db_ports_groups.assert_called_with(ctxt_mock)
-            get_conn.assert_called_with(use_master=True)
             connection_mock.vif_key.assert_any_call(1, 1)
             connection_mock.delete_key.assert_any_call("2.2")
             connection_mock.delete_key.assert_any_call("3.3")
@@ -203,7 +202,7 @@ class QuarkRedisSgToolPurgeOrphans(QuarkRedisSgToolBase):
             cli.purge_orphans(dryrun=False)
 
             db_ports_groups.assert_called_with(ctxt_mock)
-            get_conn.assert_called_with(giveup=False, use_master=True)
+            get_conn.assert_called_with(giveup=False)
             connection_mock.vif_key.assert_any_call(1, 1)
             connection_mock.delete_key.assert_any_call("2.2")
             connection_mock.delete_key.assert_any_call("3.3")
@@ -255,7 +254,6 @@ class QuarkRedisSgToolWriteGroups(QuarkRedisSgToolBase):
             connection_mock.get_rules_for_port.assert_called_with(1, 1)
 
             self.assertTrue(get_conn.call_count, 1)
-            get_conn.assert_called_with(use_master=False)
 
     def test_write_groups(self):
         with self._stubs() as (get_conn, connection_mock, db_ports_groups,
@@ -269,7 +267,6 @@ class QuarkRedisSgToolWriteGroups(QuarkRedisSgToolBase):
             connection_mock.apply_rules.assert_called_with(1, 1, "rules")
 
             self.assertTrue(get_conn.call_count, 1)
-            get_conn.assert_called_with(use_master=True)
 
     @mock.patch("time.sleep")
     def test_write_groups_raises(self, sleep):
@@ -289,5 +286,4 @@ class QuarkRedisSgToolWriteGroups(QuarkRedisSgToolBase):
             connection_mock.serialize_rules.assert_called_with([sg_rule])
             sleep.assert_called_with(1)
             self.assertTrue(get_conn.call_count, 2)
-            get_conn.assert_any_call(giveup=False, use_master=True)
-            get_conn.assert_any_call(use_master=True)
+            get_conn.assert_any_call(giveup=False)

--- a/quark/tools/redis_sg_tool.py
+++ b/quark/tools/redis_sg_tool.py
@@ -37,11 +37,6 @@ Available commands are:
     redis_sg_tool --version
 
 """
-
-VERSION = 0.1
-RETRIES = 5
-RETRY_DELAY = 1
-
 import sys
 import time
 
@@ -54,6 +49,10 @@ from oslo_config import cfg
 from quark.cache import security_groups_client as sg_client
 from quark.db import api as db_api
 from quark import exceptions as q_exc
+
+VERSION = 0.1
+RETRIES = 5
+RETRY_DELAY = 1
 
 
 class QuarkRedisTool(object):
@@ -133,7 +132,7 @@ class QuarkRedisTool(object):
         print(db_api.ports_with_security_groups_count(ctx))
 
     def purge_orphans(self, dryrun=False):
-        client = self._get_connection(use_master=not dryrun)
+        client = self._get_connection()
         ctx = neutron.context.get_admin_context()
         ports_with_groups = db_api.ports_with_security_groups_find(ctx).all()
         if dryrun:
@@ -174,8 +173,7 @@ class QuarkRedisTool(object):
                         break
                     except q_exc.RedisConnectionFailure:
                         time.sleep(self._retry_delay)
-                        client = self._get_connection(use_master=True,
-                                                      giveup=False)
+                        client = self._get_connection(giveup=False)
         if dryrun:
             print('=' * 80)
             print()
@@ -184,7 +182,7 @@ class QuarkRedisTool(object):
         print("Done!")
 
     def write_groups(self, dryrun=False):
-        client = self._get_connection(use_master=not dryrun)
+        client = self._get_connection()
         ctx = neutron.context.get_admin_context()
         ports_with_groups = db_api.ports_with_security_groups_find(ctx).all()
         if dryrun:
@@ -236,8 +234,7 @@ class QuarkRedisTool(object):
                         break
                     except q_exc.RedisConnectionFailure:
                         time.sleep(self._retry_delay)
-                        client = self._get_connection(use_master=True,
-                                                      giveup=False)
+                        client = self._get_connection(giveup=False)
 
         if dryrun:
             print()


### PR DESCRIPTION
see JIRA:NCP-1916

since the master stuff is handled by the redis client now we don't have to specify `use_master` in the args on `self._get_connection()` anymore.

also moved the other stuff down so pep8 would stop complaining

tested this a few times and all appears to be working as expected.