### PR TITLE
undefered pools during subnet select

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -796,6 +796,9 @@ def _subnet_find(context, limit, sorts, marker, page_reverse, fields,
     if "join_routes" in filters:
         query = query.options(orm.joinedload(models.Subnet.routes))
 
+    if "join_pool" in filters:
+        query = query.options(orm.undefer('_allocation_pool_cache'))
+
     return paginate_query(query, models.Subnet, limit, sorts, marker)
 
 

--- a/quark/plugin_modules/subnets.py
+++ b/quark/plugin_modules/subnets.py
@@ -402,8 +402,8 @@ def get_subnets(context, limit=None, page_reverse=False, sorts=None,
     filters = filters or {}
     subnets = db_api.subnet_find(context, limit=limit,
                                  page_reverse=page_reverse, sorts=sorts,
-                                 marker_obj=marker,
-                                 join_dns=True, join_routes=True, **filters)
+                                 marker_obj=marker, join_dns=True,
+                                 join_routes=True, join_pool=True, **filters)
     for subnet in subnets:
         cache = subnet.get("_allocation_pool_cache")
         if not cache:

--- a/quark/tests/plugin_modules/test_subnets.py
+++ b/quark/tests/plugin_modules/test_subnets.py
@@ -1660,6 +1660,7 @@ class TestQuarkGetSubnetsShared(test_quark_plugin.TestQuarkPlugin):
                                            join_routes=True,
                                            defaults=["public_v4", "public_v6"],
                                            join_dns=True,
+                                           join_pool=True,
                                            provider_query=False)
 
     def test_get_subnets_shared_false(self):
@@ -1677,7 +1678,8 @@ class TestQuarkGetSubnetsShared(test_quark_plugin.TestQuarkPlugin):
                                            defaults=[invert, "public_v4",
                                                      "public_v6"],
                                            provider_query=False,
-                                           join_routes=True, join_dns=True)
+                                           join_routes=True, join_dns=True,
+                                           join_pool=True)
 
     def test_get_subnets_no_shared(self):
         sub0 = dict(id='public_v4', tenant_id="provider", name="public_v4",
@@ -1692,4 +1694,5 @@ class TestQuarkGetSubnetsShared(test_quark_plugin.TestQuarkPlugin):
                                            None, None,
                                            defaults=[],
                                            provider_query=False,
-                                           join_routes=True, join_dns=True)
+                                           join_routes=True, join_dns=True,
+                                           join_pool=True)


### PR DESCRIPTION
JIRA:NCP-1907

This will cause a 500 ObjectDeleted exception to be raised should the
subnet be deleted during the get on the defered column