### PR TITLE
Fixed all the copyright headers to use Rackspace

### DIFF
--- a/quark/agent/agent.py
+++ b/quark/agent/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Openstack Foundation
+# Copyright 2014 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/agent/xapi.py
+++ b/quark/agent/xapi.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Openstack Foundation
+# Copyright 2014 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/allocation_pool.py
+++ b/quark/allocation_pool.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Openstack Foundation
+# Copyright 2014 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/api/auth.py
+++ b/quark/api/auth.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 OpenStack Foundation
+# Copyright (c) 2013 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/api/extensions/diagnostics.py
+++ b/quark/api/extensions/diagnostics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 OpenStack Foundation
+# Copyright (c) 2013 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/api/extensions/floatingip.py
+++ b/quark/api/extensions/floatingip.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 OpenStack Foundation
+# Copyright (c) 2013 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/api/extensions/ip_addresses.py
+++ b/quark/api/extensions/ip_addresses.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 OpenStack Foundation
+# Copyright (c) 2013 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/api/extensions/ip_availability.py
+++ b/quark/api/extensions/ip_availability.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 OpenStack Foundation
+# Copyright (c) 2015 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/api/extensions/ip_policies.py
+++ b/quark/api/extensions/ip_policies.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 OpenStack Foundation
+# Copyright (c) 2013 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/api/extensions/mac_address_ranges.py
+++ b/quark/api/extensions/mac_address_ranges.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 OpenStack Foundation
+# Copyright (c) 2013 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/api/extensions/networks_quark.py
+++ b/quark/api/extensions/networks_quark.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 OpenStack Foundation
+# Copyright (c) 2013 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/api/extensions/ports_quark.py
+++ b/quark/api/extensions/ports_quark.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 OpenStack Foundation
+# Copyright (c) 2013 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/api/extensions/routes.py
+++ b/quark/api/extensions/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 OpenStack Foundation
+# Copyright (c) 2013 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/api/extensions/scalingip.py
+++ b/quark/api/extensions/scalingip.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 OpenStack Foundation
+# Copyright (c) 2013 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/api/extensions/segment_allocation_ranges.py
+++ b/quark/api/extensions/segment_allocation_ranges.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 OpenStack Foundation
+# Copyright (c) 2013 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/api/extensions/subnets_quark.py
+++ b/quark/api/extensions/subnets_quark.py
@@ -1,6 +1,4 @@
-# vim: tabstop=4 shiftwidth=4 softtabstop=4
-
-# Copyright (c) 2013 OpenStack Foundation.
+# Copyright (c) 2013 Rackspace Hosting Inc.
 # All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/billing.py
+++ b/quark/billing.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Openstack Foundation
+# Copyright 2016 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/cache/redis_base.py
+++ b/quark/cache/redis_base.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Openstack Foundation
+# Copyright 2014 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/cache/security_groups_client.py
+++ b/quark/cache/security_groups_client.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Openstack Foundation
+# Copyright 2014 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/db/custom_types.py
+++ b/quark/db/custom_types.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012 OpenStack Foundation
+# Copyright (c) 2012 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/db/ip_types.py
+++ b/quark/db/ip_types.py
@@ -1,3 +1,17 @@
+# Copyright 2016 Rackspace Hosting Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
 SHARED = 'shared'
 FIXED = 'fixed'
 FLOATING = 'floating'

--- a/quark/db/models.py
+++ b/quark/db/models.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/drivers/base.py
+++ b/quark/drivers/base.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/drivers/floating_ip_registry.py
+++ b/quark/drivers/floating_ip_registry.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/drivers/ironic_driver.py
+++ b/quark/drivers/ironic_driver.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/drivers/nvp_driver.py
+++ b/quark/drivers/nvp_driver.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/drivers/optimized_nvp_driver.py
+++ b/quark/drivers/optimized_nvp_driver.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/drivers/registry.py
+++ b/quark/drivers/registry.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/drivers/registry_base.py
+++ b/quark/drivers/registry_base.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/drivers/security_groups.py
+++ b/quark/drivers/security_groups.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Openstack Foundation
+# Copyright 2014 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/drivers/unicorn_driver.py
+++ b/quark/drivers/unicorn_driver.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/drivers/unmanaged.py
+++ b/quark/drivers/unmanaged.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/environment.py
+++ b/quark/environment.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 OpenStack Foundation
+# Copyright (c) 2015 Rackspace Hosting Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quark/exceptions.py
+++ b/quark/exceptions.py
@@ -1,3 +1,17 @@
+# Copyright 2016 Rackspace Hosting Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
 from neutron_lib import exceptions as n_exc
 
 

--- a/quark/gunicorn_server.py
+++ b/quark/gunicorn_server.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python
+# Copyright 2016 Rackspace Hosting Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
 import sys
 
 from gunicorn.app import base

--- a/quark/ip_availability.py
+++ b/quark/ip_availability.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Openstack Foundation
+# Copyright 2014 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/ipam.py
+++ b/quark/ipam.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/network_strategy.py
+++ b/quark/network_strategy.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin_extensions/providernets.py
+++ b/quark/plugin_extensions/providernets.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin_modules/floating_ips.py
+++ b/quark/plugin_modules/floating_ips.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin_modules/ip_addresses.py
+++ b/quark/plugin_modules/ip_addresses.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin_modules/ip_policies.py
+++ b/quark/plugin_modules/ip_policies.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin_modules/mac_address_ranges.py
+++ b/quark/plugin_modules/mac_address_ranges.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin_modules/networks.py
+++ b/quark/plugin_modules/networks.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin_modules/ports.py
+++ b/quark/plugin_modules/ports.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin_modules/router.py
+++ b/quark/plugin_modules/router.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin_modules/routes.py
+++ b/quark/plugin_modules/routes.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin_modules/security_groups.py
+++ b/quark/plugin_modules/security_groups.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin_modules/segment_allocation_ranges.py
+++ b/quark/plugin_modules/segment_allocation_ranges.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin_modules/subnets.py
+++ b/quark/plugin_modules/subnets.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/protocols.py
+++ b/quark/protocols.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Openstack Foundation
+# Copyright 2014 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/segment_allocations.py
+++ b/quark/segment_allocations.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tags.py
+++ b/quark/tags.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Rackspace
+# Copyright 2015 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/cache/test_security_groups_client.py
+++ b/quark/tests/cache/test_security_groups_client.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Openstack Foundation
+# Copyright 2014 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/functional/plugin_modules/test_ip_addresses.py
+++ b/quark/tests/functional/plugin_modules/test_ip_addresses.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Openstack Foundation
+# Copyright 2014 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/functional/plugin_modules/test_networks.py
+++ b/quark/tests/functional/plugin_modules/test_networks.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/functional/plugin_modules/test_ports.py
+++ b/quark/tests/functional/plugin_modules/test_ports.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/functional/plugin_modules/test_routes.py
+++ b/quark/tests/functional/plugin_modules/test_routes.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/functional/plugin_modules/test_segment_allocation.py
+++ b/quark/tests/functional/plugin_modules/test_segment_allocation.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/functional/plugin_modules/test_shared_ips.py
+++ b/quark/tests/functional/plugin_modules/test_shared_ips.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Openstack Foundation
+# Copyright 2014 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/functional/plugin_modules/test_subnets.py
+++ b/quark/tests/functional/plugin_modules/test_subnets.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/plugin_modules/test_floating_ips.py
+++ b/quark/tests/plugin_modules/test_floating_ips.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/plugin_modules/test_ip_addresses.py
+++ b/quark/tests/plugin_modules/test_ip_addresses.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/plugin_modules/test_ip_policies.py
+++ b/quark/tests/plugin_modules/test_ip_policies.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/plugin_modules/test_mac_address_ranges.py
+++ b/quark/tests/plugin_modules/test_mac_address_ranges.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/plugin_modules/test_networks.py
+++ b/quark/tests/plugin_modules/test_networks.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/plugin_modules/test_ports.py
+++ b/quark/tests/plugin_modules/test_ports.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/plugin_modules/test_routes.py
+++ b/quark/tests/plugin_modules/test_routes.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/plugin_modules/test_security_groups.py
+++ b/quark/tests/plugin_modules/test_security_groups.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/plugin_modules/test_subnets.py
+++ b/quark/tests/plugin_modules/test_subnets.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/test_db_api.py
+++ b/quark/tests/test_db_api.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/test_db_custom_types.py
+++ b/quark/tests/test_db_custom_types.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/test_driver_registry.py
+++ b/quark/tests/test_driver_registry.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/test_ironic_driver.py
+++ b/quark/tests/test_ironic_driver.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/test_network_strategies.py
+++ b/quark/tests/test_network_strategies.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/test_nvp_driver.py
+++ b/quark/tests/test_nvp_driver.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/test_optimized_nvp_driver.py
+++ b/quark/tests/test_optimized_nvp_driver.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/test_quark_plugin.py
+++ b/quark/tests/test_quark_plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tests/test_unmanaged_driver.py
+++ b/quark/tests/test_unmanaged_driver.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tools/billing.py
+++ b/quark/tools/billing.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Openstack Foundation
+# Copyright 2016 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/tools/redis_sg_tool.py
+++ b/quark/tools/redis_sg_tool.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2014 Openstack Foundation
+# Copyright 2014 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/quark/utils.py
+++ b/quark/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Openstack Foundation
+# Copyright 2013 Rackspace Hosting Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may


### PR DESCRIPTION
As we are not actually employed by the openstack foundation we cannot
legally use the Openstack Foundation on our copyrights.