### PR TITLE
don't allow port with gateway ip on flip associate

### DIFF
--- a/quark/exceptions.py
+++ b/quark/exceptions.py
@@ -190,6 +190,11 @@ class PortAlreadyContainsFloatingIp(n_exc.Conflict):
     message = _("Port %(port_id)s already has an associated floating IP.")
 
 
+class FixedIpAllocatedToGatewayIp(n_exc.Conflict):
+    message = _("Fixed IP allocated to port %(port_id)s of network "
+                "%(network_id)s that matches gateway IP of floating IP subnet")
+
+
 class FixedIpDoesNotExistsForPort(n_exc.BadRequest):
     message = _("Fixed IP %(fixed_ip)s does not exist on Port %(port_id)s")
 

--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -104,7 +104,7 @@ def _make_subnet_dict(subnet, fields=None):
 
     if (CONF.QUARK.show_allocation_pools and not
             STRATEGY.is_provider_subnet(subnet_id)):
-        res["allocation_pools"] = subnet.allocation_pools
+        res["allocation_pools"] = subnet.get('allocation_pools')
     else:
         res["allocation_pools"] = []
 


### PR DESCRIPTION
before we associate a floating ip, we need to verify that a port on the network does not exist that is assigned a fixed ip that matches the gateway ip of the floating ip subnet